### PR TITLE
Ctrl-Enter, Ctrl-S tooltips added for Run and Save buttons

### DIFF
--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -102,7 +102,7 @@ function updateTopControls(addHistory) {
   } else {
     if (m.data && m.data.file) {
       buttons.push(
-        {id: 'save', label: 'Save',
+        {id: 'save', title: 'Ctrl+S', label: 'Save',
          disabled: !specialowner() && model.username &&
                    !view.isPaneEditorDirty(paneatpos('left')) });
     }
@@ -128,7 +128,7 @@ function updateTopControls(addHistory) {
         {id: 'guide', label: '<span class=helplink>Guide</span>' });
     }
   }
-  // buttons.push({id: 'done', label: 'Done'});
+  // buttons.push({id: 'done', label: 'Done', title: 'tooltip text'});
   view.showButtons(buttons);
   // Update middle button.
   if (m.data && m.data.file ||

--- a/site/top/src/editor-view.js
+++ b/site/top/src/editor-view.js
@@ -474,7 +474,7 @@ $('#buttonbar').on('change', 'input[type=checkbox]', function(e) {
 });
 
 // buttonlist should be
-// [{label:, id:, callback:, checkbox:, checked:, disabled:}]
+// [{label:, id:, callback:, checkbox:, checked:, disabled:, title:}]
 function showButtons(buttonlist) {
   var bar = $('#buttonbar');
   var html = '';
@@ -486,15 +486,21 @@ function showButtons(buttonlist) {
         (buttonlist[j].id ? ' id="' + buttonlist[j].id + '"' : '') +
         (buttonlist[j].checked ? ' checked' : '') +
         (buttonlist[j].disabled ? ' disabled' : '') +
+        (buttonlist[j].title ? ' title="' + buttonlist[j].title + '"' : '') +
         '>' + buttonlist[j].label + '</label></button>';
     } else {
       html += '<button' +
         (buttonlist[j].id ? ' id="' + buttonlist[j].id + '"' : '') +
-        (buttonlist[j].disabled ? ' disabled' : '') +
+        (buttonlist[j].disabled ? ' disabled' : '') + 
+        (buttonlist[j].title ? ' title="' + buttonlist[j].title + '"' : '') +
         '>' + buttonlist[j].label + '</button>';
     }
   }
   bar.html(html);
+  
+  // set tooltip for the save button after the buttons are
+  // registered with the buttonbar
+  $('#save').tooltipster();
 }
 
 function enableButton(id, enable) {
@@ -517,11 +523,13 @@ $(window).on('resize.middlebutton', centerMiddle);
 function showMiddleButton(which) {
   if (which == 'run') {
     $('#middle').find('div').eq(0).html(
-      '<button id="run"><div class="triangle"></div></button>');
+      '<button id="run" title="Ctrl+Enter"><div class="triangle"></div></button>');
     if (state.previewMode) {
       $('#middle').show();
       centerMiddle();
     }
+    // set tooltip for the run button
+    $('#run').tooltipster();
   } else if (which == 'edit' && state.previewMode) {
     $('#middle').find('div').eq(0).html(
       '<button id="edit">&#x25c1;</button>');


### PR DESCRIPTION
Updated code from orig branch, pencilcode-site_bug#15 (tooltips for Save and Run buttons)
to branch bug15.  Fixed tooltip text from lower case 'c' to uppercase 'C' in Ctrl-<func>.  Fixed tooltip
text Ctrl-R to Ctrl-Enter for run button.  Tested w/Chrome browser on Windows 7 host.
