### PR TITLE
Add a stop button.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,14 +198,28 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.task.registerTask('test', 'Run integration tests.',
+  function(testname) {
+    if (!!testname) {
+      grunt.config('mochaTest.test.src', ['test/' + testname + '.js']);
+    }
+    grunt.task.run('express:test');
+    grunt.task.run('mochaTest');
+  });
+
+  grunt.task.registerTask('devtest', 'Run tests using uncompiled code.',
+  function(testname) {
+    if (!!testname) {
+      grunt.config('mochaTest.test.src', ['test/' + testname + '.js']);
+    }
+    grunt.task.run('express:devtest');
+    grunt.task.run('mochaTest');
+  });
+
   // "devserver" serves editor code directly from the src directory.
   grunt.registerTask('devserver', ['proxymessage', 'watch:dev']);
   // "compserver" serves the compiled editor code, not the source.
   grunt.registerTask('compserver', ['proxymessage', 'watch:comp']);
-  // "test" tests the compiled editor code.
-  grunt.registerTask('test', ['express:test', 'mochaTest']);
-  // "devtest" tests the uncompiled source code.
-  grunt.registerTask('devtest', ['express:devtest', 'mochaTest']);
   // "debug" overwrites turtlebits.js with an unminified version.
   grunt.registerTask('debug', ['concat', 'devtest']);
   // default target: compile editor code and uglify turtlebits.js, and test it.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-bowercopy": "0.4.1",
     "grunt-cli": "0.1.11",
     "grunt-contrib-uglify": "0.2.7",
-    "phantomjs": "1.9.2-6",
+    "phantomjs": "1.9.7-1",
     "express": "~3.4.7",
     "http-proxy": "~0.10.4",
     "connect": "~2.12.0",

--- a/site/top/editor.css
+++ b/site/top/editor.css
@@ -69,15 +69,16 @@ body {margin:0;padding:0;font:24px/28px "Lato";font-weight:700;overflow:hidden}
 #middle{z-index:1;display:none;}
 #middle,.vcenter{position:absolute;left:50%;top:50%}
 .hcenter{margin:-50% -50%;}
-#run {border:0;background-color:rgba(255,255,255,0.7);opacity:0.7;
-  box-shadow:0 0 7px gray;color:dodgerblue;
-  border-radius:20px;font-family:inherit;font-size:60px;line-height:60px;
-  padding:10px 10px 10px 15px;margin:0;display:inline-block;}
-#run:hover {box-shadow:0 0 7px black;opacity:0.9}
-#run.pressed:hover { box-shadow: 0 0 14px black; opacity: 1; }
+#run,#stop {border:0;background-color:rgba(255,255,255,0.7);opacity:0.7;
+  box-shadow:0 0 7px gray;color:dodgerblue;border-radius:20px;
+  padding:10px 10px 10px 10px;margin:0;display:inline-block;}
+#run:hover,#stop:hover {box-shadow:0 0 7px black;opacity:0.9}
+#run.pressed:hover,#stop.pressed:hover {box-shadow:0 0 14px black;opacity:1;}
 #run .triangle {width:0;height:0;font-size:0;line-height:0;
   border-bottom:20px solid transparent;border-top:20px solid transparent;
-  border-left:36px solid dodgerblue;}
+  border-left:36px solid dodgerblue; margin-left: 6px;}
+#stop .square {width:0;height:0;font-size:0;line-height:0;
+  border:16px solid dodgerblue; margin: 4px 5px;}
 .panetitle,#owner{user-select:none;-webkit-user-select:none;
   -moz-user-select:none;cursor:default;}
 #owner:hover{text-decoration:underline;}

--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -842,6 +842,7 @@ function noteIfUnsaved(position) {
 }
 
 function rotateModelLeft(addHistory) {
+  debug.bindframe(null);
   view.rotateLeft();
   if (modelatpos('back').running) {
     runCodeAtPosition('back', '', null);
@@ -851,6 +852,7 @@ function rotateModelLeft(addHistory) {
 }
 
 function rotateModelRight(addHistory) {
+  debug.bindframe(null);
   view.rotateRight();
   if (modelatpos('back').running) {
     runCodeAtPosition('back', '', null);
@@ -970,7 +972,10 @@ function nextLoadNumber() {
   return ++loadNumber;
 }
 
+var stopButtonTimer = null;
+
 function cancelAndClearPosition(pos) {
+  debug.bindframe(null);
   view.clearPane(paneatpos(pos), false);
   modelatpos(pos).loading = 0;
   modelatpos(pos).filename = null;
@@ -994,7 +999,9 @@ function runCodeAtPosition(position, code, filename) {
   // grabs focus.  TODO: investigate editor.focus() within on('run') and
   // remove this setTimeout if we can make editor.focus() work without delay.
   setTimeout(function() {
-    view.setPaneRunText(pane, code, filename, baseUrl);
+    if (m.running) {
+      view.setPaneRunText(pane, code, filename, baseUrl);
+    }
   }, 0);
   if (code) {
     $.get('/log/' + filename + '?run=' +

--- a/site/top/src/editor-view.js
+++ b/site/top/src/editor-view.js
@@ -524,13 +524,22 @@ $(window).on('resize.middlebutton', centerMiddle);
 function showMiddleButton(which) {
   if (which == 'run') {
     $('#middle').find('div').eq(0).html(
-      '<button id="run" title="Ctrl+Enter"><div class="triangle"></div></button>');
+      '<button id="run" title="Ctrl+Enter">' +
+      '<div class="triangle"></div></button>');
     if (state.previewMode) {
       $('#middle').show();
       centerMiddle();
     }
     // set tooltip for the run button
     $('#run').tooltipster();
+  } else if (which == 'stop') {
+    $('#middle').find('div').eq(0).html(
+      '<button id="stop">' +
+      '<div class="square"></div></button>');
+    if (state.previewMode) {
+      $('#middle').show();
+      centerMiddle();
+    }
   } else if (which == 'edit' && state.previewMode) {
     $('#middle').find('div').eq(0).html(
       '<button id="edit">&#x25c1;</button>');
@@ -1099,6 +1108,8 @@ function setPaneEditorText(pane, text, filename) {
   editor.getSession().setUndoManager(um);
   editor.getSession().on('change', function() {
     ensureEmptyLastLine(editor);
+    // Any editing ends the debugging session.
+    require('editor-debug').bindframe(null);
     clearPaneEditorMarks(pane);
     if (editor.getFontSize() > 16) {
       if (editor.getSession().getLength() *

--- a/test/debug_code.js
+++ b/test/debug_code.js
@@ -1,0 +1,173 @@
+var phantom = require('node-phantom-simple'),
+    phantomjs = require('phantomjs'),
+    assert = require('assert'),
+    testutil = require('./lib/testutil'),
+    one_step_timeout = 8000,
+    refreshThen = testutil.refreshThen,
+    asyncTest = testutil.asyncTest;
+
+describe('code debugger', function() {
+  var _ph, _page;
+  before(function(done) {
+    // Create the headless webkit browser.
+    phantom.create(function(error, ph) {
+      assert.ifError(error);
+      // Open a page for browsing.
+      _ph = ph;
+      _ph.createPage(function(err, page) {
+        _page = page;
+        // Set the size to a modern laptop size.
+        page.set('viewportSize', { width: 1200, height: 900 }, function(err) {
+          assert.ifError(err);
+          // Point it to a blank page to start
+          page.open('about:blank', function(err, status){
+            assert.ifError(err);
+            assert.equal(status, 'success');
+            done();
+          });
+        });
+      });
+    }, {
+      // Launch phantomjs from the phantomjs package.
+      phantomPath: phantomjs.path,
+      parameters: {
+        // Use the test server as a proxy server, so that all requests
+        // go to this server (instead of trying real DNS lookups).
+        proxy: '127.0.0.1:8193',
+        // Set the disk storage to zero to avoid persisting localStorage
+        // between test runs.
+        'local-storage-quota': 0
+      }
+    });
+  });
+  after(function() {
+    // Be sure to kill the browser when the test is done, or else
+    // we can leave orphan processes.
+    _ph.exit();
+  });
+  it('should show run button when loading code', function(done) {
+    // Navigate to see the editor for the program named "first".
+    _page.open('http://livetest.pencilcode.net.dev/edit/hi',
+        function(err, status) {
+      assert.ifError(err);
+      assert.equal(status, 'success');
+      asyncTest(_page, one_step_timeout, null, null, function() {
+        // Poll until the element with class="editor" appears on the page.
+        if (!$('.editor').length) return;
+        // Reach in and return the text that is shown within the editor.
+        var ace_editor = ace.edit($('.editor').attr('id'));
+        return {
+          text: ace_editor.getSession().getValue(),
+          runbuttoncount: $('#run').length
+        };
+      }, function(err, result) {
+        assert.ifError(err);
+        // The editor text should contain this line of code.
+        assert.ok(/pen blue/.test(result.text));
+        assert.equal(result.runbuttoncount, 1);
+        done();
+      });
+    });
+  });
+  it('should be able to run the program', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Click on the triangle run button.
+      $('#run').mousedown();
+      $('#run').click();
+    }, function() {
+      try {
+        // Wait for the preview frame to show
+        if (!$('.preview iframe').length) return;
+        if (!$('.preview iframe')[0].contentWindow.see) return;
+        // Evaluate some expression in the coffeescript evaluation window.
+        var seval = $('.preview iframe')[0].contentWindow.see.eval;
+        // And also wait for the turtle to start moving.
+        if (seval('getxy()')[1] < 10) return;
+        return {
+          direction: seval('direction()'),
+          getxy: seval('getxy()'),
+          touchesred: seval('touches red'),
+          touchesblue: seval('touches blue'),
+          queuelen: seval('turtle.queue().length'),
+          stopcount: $('#stop').length
+        };
+      }
+      catch(e) {
+        return {poll: true, error: e};
+      }
+    }, function(err, result) {
+      assert.ifError(err);
+      // The first move is forward....
+      assert.equal(0, result.direction);
+      assert.ok(Math.abs(result.getxy[0] - 0) < 1e-6);
+      // The turtle should not be touching any red pixels.
+      assert.equal(false, result.touchesred);
+      // The turtle should be touching blue pixels that it drew.
+      assert.equal(true, result.touchesblue);
+      // The turtle should still have lots of queued actions.
+      assert.ok(result.queuelen > 0);
+      // The stop button should be showing
+      assert.equal(1, result.stopcount);
+      done();
+    });
+  });
+  it('should be able to stop the program', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Click on the square stop button.
+      $('#stop').mousedown();
+      $('#stop').click();
+    }, function() {
+      try {
+        if (!$('.preview iframe').length) return;
+        if (!$('.preview iframe')[0].contentWindow.see) return;
+        // Evaluate some expression in the coffeescript evaluation window.
+        var seval = $('.preview iframe')[0].contentWindow.see.eval;
+        // Reset interrupts so that we can evaluate some expressions.
+        seval('interrupt("reset")');
+        // And also wait for the turtle to start moving.
+        return {
+          touchesred: seval('touches red'),
+          touchesblue: seval('touches blue'),
+          queuelen: seval('turtle.queue().length'),
+          debugtracecount: $('.debugtrace'),
+          debugtracetop: $('.debugtrace').css('top')
+        };
+      }
+      catch(e) {
+        return {poll: true, error: e};
+      }
+    }, function(err, result) {
+      assert.ifError(err);
+      // The turtle should not be touching any red pixels.
+      assert.equal(false, result.touchesred);
+      // The turtle should be touching blue pixels that it drew.
+      assert.equal(true, result.touchesblue);
+      // The turtle should not be moving any more.
+      assert.equal(0, result.queuelen);
+      /* TODO: investigate if PhantomJS stack traces can be parsed.
+       * For now, line tracing dosn't work on PhantomJS, so these tests
+       * are disabled.
+      // A line of code should be traced.
+      assert.equal(1, result.debugtracecount);
+      // The traced code should be around line 4 or beyond.
+      assert.ok(parseInt(result.debugtracetop) > 80);
+      */
+      done();
+    });
+  });
+  it('is done', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Final cleanup: delete local storage and the cookie.
+      localStorage.clear();
+      document.cookie='login=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    }, function() {
+      return {
+        cookie: document.cookie
+      };
+    }, function(err, result) {
+      assert.ifError(err);
+      assert.ok(!/login=/.test(result.cookie));
+      done();
+    });
+  });
+});

--- a/test/edit_code.js
+++ b/test/edit_code.js
@@ -1,101 +1,10 @@
 var phantom = require('node-phantom-simple'),
     phantomjs = require('phantomjs'),
     assert = require('assert'),
-    one_step_timeout = 8000;
-
-function refreshThen(page, callback) {
-  page.reload(function(err) {
-    assert.ifError(err);
-    // Wait a little time before interacting with the page after a refresh.
-    setTimeout(callback, 100);
-  });
-}
-
-// asyncTest does a single async test using a headless webkit.
-//
-// In these tests, there is the testing process driving the tests
-// and checking assertions, and there is the headless webkit process
-// running the website being tested. This function performs a
-// three-step dance that is used in many of the tests.
-//
-// 1. (in webkit) it runs an "action" script once in the browser.
-//    This is typically a simulation of a user action like clicking
-//    on a button.
-// 2. (in webkit) it waits for some condition to be satisfied in the
-//    browser by polling a "predicate" script in the browser
-//    repeatedly.  If the predicate returns without a value,
-//    it is not yet done and it needs to be polled again.
-//    When the predicate returns a value (usually a JSON tuple),
-//    it is done.
-// 3. (back in the test process) the results of the predicate or
-//    error (if there was one) are passed to a callback in the
-//    main testing process.  The callback can do the test validation.
-//
-// Parameters:
-//
-// page the node-phantom page object being tested.
-//   The action and predicate will be evaluated within this page.
-// timeout is the amount of time, in milliseconds, that are allowed
-//   after which the test can fail.
-// params is an optional array of values to be marshalled from the
-//   test process to the browser.  These will be given as arguments
-//   to both the action and predicate functions.
-// action is a function to execute once within the browser.
-//   Note that although action is written as as a function in the
-//   test process, it is actually not run in the test process: it is
-//   just serialized as a source code string to be evaled within the
-//   browser.  Therefore nonlocal variables such as globals or
-//   calls to functions within the test process will not work.
-// predicate a function to execute repeatedly within the browser.
-//   Again this is run in the browser to the same rules apply.
-//   If the predicate returns without a value, or with a value that
-//   has a non-false property "poll", it will be called again
-//   unless the timeout has elapsed.  If the predicate returns with
-//   a value, the polling will stop and the value will be passed
-//   to the callback.
-// callback is called when the predicate is satisfied or when
-//   an error occurs.  It is passed (err, result) where err is
-//   non-null if there was an error, and result is the result
-//   of the predicate if there wasn't.
-function asyncTest(page, timeout, params, action, predicate, callback) {
-  var startTime = +(new Date), evalTime = startTime,
-      rt_args, ac_args;
-
-  function handletry(err, result) {
-    if (err || (result != null && !result.poll)) {
-      callback(err, result);
-    } else if (evalTime - startTime > timeout) {
-      // Note that timeout is measured not from the time
-      // of the callback, but the time of the call-in.
-      // After a slow callback, we can try one more time.
-      throw (new Error('timeout'));
-    } else {
-      if (result) { console.log(result); }
-      setTimeout(retry, 100);
-    }
-  }
-  function retry() {
-    evalTime = +(new Date);
-    page.evaluate.apply(page, rt_args);
-  }
-  function handleact(err, result) {
-    if (err) {
-      callback(err);
-    }
-    retry();
-  }
-
-  rt_args = [ predicate, handletry ];
-  ac_args = [ action, handleact ];
-  rt_args.push.apply(rt_args, params);
-  ac_args.push.apply(ac_args, params);
-
-  if (action) {
-    page.evaluate.apply(page, ac_args);
-  } else {
-    retry();
-  }
-}
+    testutil = require('./lib/testutil'),
+    one_step_timeout = 8000,
+    refreshThen = testutil.refreshThen,
+    asyncTest = testutil.asyncTest;
 
 describe('code editor', function() {
   var _ph, _page;

--- a/test/lib/testutil.js
+++ b/test/lib/testutil.js
@@ -1,0 +1,98 @@
+var assert = require('assert');
+
+exports.refreshThen =
+function refreshThen(page, callback) {
+  page.reload(function(err) {
+    assert.ifError(err);
+    // Wait a little time before interacting with the page after a refresh.
+    setTimeout(callback, 100);
+  });
+}
+
+// asyncTest does a single async test using a headless webkit.
+//
+// In these tests, there is the testing process driving the tests
+// and checking assertions, and there is the headless webkit process
+// running the website being tested. This function performs a
+// three-step dance that is used in many of the tests.
+//
+// 1. (in webkit) it runs an "action" script once in the browser.
+//    This is typically a simulation of a user action like clicking
+//    on a button.
+// 2. (in webkit) it waits for some condition to be satisfied in the
+//    browser by polling a "predicate" script in the browser
+//    repeatedly.  If the predicate returns without a value,
+//    it is not yet done and it needs to be polled again.
+//    When the predicate returns a value (usually a JSON tuple),
+//    it is done.
+// 3. (back in the test process) the results of the predicate or
+//    error (if there was one) are passed to a callback in the
+//    main testing process.  The callback can do the test validation.
+//
+// Parameters:
+//
+// page the node-phantom page object being tested.
+//   The action and predicate will be evaluated within this page.
+// timeout is the amount of time, in milliseconds, that are allowed
+//   after which the test can fail.
+// params is an optional array of values to be marshalled from the
+//   test process to the browser.  These will be given as arguments
+//   to both the action and predicate functions.
+// action is a function to execute once within the browser.
+//   Note that although action is written as as a function in the
+//   test process, it is actually not run in the test process: it is
+//   just serialized as a source code string to be evaled within the
+//   browser.  Therefore nonlocal variables such as globals or
+//   calls to functions within the test process will not work.
+// predicate a function to execute repeatedly within the browser.
+//   Again this is run in the browser to the same rules apply.
+//   If the predicate returns without a value, or with a value that
+//   has a non-false property "poll", it will be called again
+//   unless the timeout has elapsed.  If the predicate returns with
+//   a value, the polling will stop and the value will be passed
+//   to the callback.
+// callback is called when the predicate is satisfied or when
+//   an error occurs.  It is passed (err, result) where err is
+//   non-null if there was an error, and result is the result
+//   of the predicate if there wasn't.
+exports.asyncTest =
+function asyncTest(page, timeout, params, action, predicate, callback) {
+  var startTime = +(new Date), evalTime = startTime,
+      rt_args, ac_args;
+
+  function handletry(err, result) {
+    if (err || (result != null && !result.poll)) {
+      callback(err, result);
+    } else if (evalTime - startTime > timeout) {
+      // Note that timeout is measured not from the time
+      // of the callback, but the time of the call-in.
+      // After a slow callback, we can try one more time.
+      throw (new Error('timeout'));
+    } else {
+      if (result) { console.log(result); }
+      setTimeout(retry, 100);
+    }
+  }
+  function retry() {
+    evalTime = +(new Date);
+    page.evaluate.apply(page, rt_args);
+  }
+  function handleact(err, result) {
+    if (err) {
+      callback(err);
+    }
+    retry();
+  }
+
+  rt_args = [ predicate, handletry ];
+  ac_args = [ action, handleact ];
+  rt_args.push.apply(rt_args, params);
+  ac_args.push.apply(ac_args, params);
+
+  if (action) {
+    page.evaluate.apply(page, ac_args);
+  } else {
+    retry();
+  }
+}
+


### PR DESCRIPTION
Turtle animations can now be stopped.  When running a program
that supports $.turtle.interrupt, the IDE now polls (every 0.1 sec)
$.turtle.interrupt('test') and shows a stop button when true.

Clicking on the stop button injects an interrupt() call into the
running program, stopping animation.
