### PR TITLE
Improve gutter mouseover debug UI.

### DIFF
--- a/site/top/editor.css
+++ b/site/top/editor.css
@@ -101,7 +101,8 @@ body {margin:0;padding:0;font:24px/28px "Lato";font-weight:700;overflow:hidden}
 /* Code line highlighting for mouse-focused code */
 .debugfocus{position:absolute;background:yellow;z-index:2;}
 /* Gutter line highlighting for lines that can be mouseovered */
-.guttermouseable{background:bisque;}
+div.guttermouseable{background-position:right;background-repeat:repeat-y;
+  background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAABCAYAAAAW/mTzAAAAEElEQVQIW2P8/5/hPwMaAAA38gL/hSCOCgAAAABJRU5ErkJggg==);}
 body#pencilcode #diigolet-csm {
   /* Disable the diigo csm popup, which gets in the way of the editor. */
   display: none!important;

--- a/site/top/src/editor-debug.js
+++ b/site/top/src/editor-debug.js
@@ -40,6 +40,7 @@ function bindframe(w) {
   cachedSourceMaps = {};
   cachedParseStack = {};
   view.clearPaneEditorMarks(view.paneid('left'));
+  view.notePaneEditorCleanLineCount(view.paneid('left'));
   firstSessionId = nextDebugId;
   if (stopButtonShown == 1) {
     view.showMiddleButton('run');

--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -294,7 +294,12 @@ view.on('byname', function() {
 view.on('dirty', function(pane) {
   if (posofpane(pane) == 'left') {
     view.enableButton('save', specialowner() || view.isPaneEditorDirty(pane));
-    // End debugging session when text is edited.
+  }
+});
+
+view.on('changelines', function(pane) {
+  // End debugging session when number of lines is changed.
+  if (posofpane(pane) == 'left') {
     debug.bindframe(null);
   }
 });


### PR DESCRIPTION
- Gutter highlight is less intrusive and more suggestive of yellow highight.
- Mouseover only works on gutter items that have been highlighted.
- Highlighting is not cleared until the "changelines" event is fired,
  i.e., a small edit will not stop the highlighting: you have to add or
  delete a line before we stop the highlighting.
