### PR TITLE
Instant feedback when the run button is pressed.

### DIFF
--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -326,6 +326,8 @@ view.on('run', function() {
     storage.saveFile(model.ownername,
         modelatpos('left').filename, newdata, false, null, true);
   }
+  // Provide instant (momentary) feedback that the program is now running.
+  debug.flashStopButton();
   runCodeAtPosition('right', runtext, modelatpos('left').filename);
   if (!specialowner()) {
     cookie('recent', window.location.href,


### PR DESCRIPTION
When you press the "run" button, it now immediately switches to
the "stop" button for one second, regardless of whether the program
is actually interruptable (yet).  The reason is to just give the
user instant feedback that their run is actually underway.

If the program is actually interruptable, a polling loop will come
in, cancel the one-second timer, and start maintaining the status of
the stop-button based on the actual run status of the program.

If the program is not interruptable (e.g. it's a plain HTML page
or a script that isn't IDE-aware), then the stop-button will
just flip back to a run button after one second.
