### PR TITLE
Autoselect font size to avoid wrapping.

### DIFF
--- a/site/top/src/editor-view.js
+++ b/site/top/src/editor-view.js
@@ -1336,6 +1336,18 @@ function fixRepeatedCtrlFCommand(editor) {
   }])
 }
 
+function getTextRowsAndColumns(text) {
+  var rawlines = text.split('\n');
+  var columns = 0;
+  for (var j = 0; j < rawlines.length; ++j) {
+    columns = Math.max(columns, rawlines[j].length);
+  }
+  return {
+    rows: rawlines.length,
+    columns: columns
+  };
+}
+
 // Initializes an (ACE) editor into a pane, using the given text and the
 // given filename.
 // @param pane the id of a pane - alpha, bravo or charlie.
@@ -1361,13 +1373,19 @@ function setPaneEditorText(pane, text, filename) {
   editor.getSession().setUseWrapMode(true);
   editor.getSession().setTabSize(2);
   editor.getSession().setMode(modeForMimeType(paneState.mimeType));
-  var lines = text.split('\n').length;
-  var long = (lines * 24 * 1.4 > $('#' + pane).height());
+  var dimensions = getTextRowsAndColumns(text);
+  // A big font char is 14 pixels wide and 29 pixels high.
+  var big = { width: 14, height: 29 };
+  // We're "long" if we bump out of the pane rectangle.
+  var long = ((dimensions.rows + 2) * big.height > $('#' + pane).height() ||
+              (dimensions.columns + 1) * big.width > $('#' + pane).width());
   if (long) {
-    $('.editor').css({fontWeight: 500, lineHeight: '129%'});
+    // Use a small font for long documents.
+    $('#' + pane + ' .editor').css({fontWeight: 500, lineHeight: '119%'});
     editor.setFontSize(16);
   } else {
-    $('.editor').css({fontWeight: 600, lineHeight: '121%'});
+    // Use a giant font for short documents.
+    $('#' + pane + ' .editor').css({fontWeight: 600, lineHeight: '121%'});
     editor.setFontSize(24);
   }
   editor.setValue(text);
@@ -1376,11 +1394,22 @@ function setPaneEditorText(pane, text, filename) {
   editor.getSession().setUndoManager(um);
   editor.getSession().on('change', function() {
     ensureEmptyLastLine(editor);
+    // Flip editor to small font size when it doesn't fit any more.
     if (editor.getFontSize() > 16) {
-      if (editor.getSession().getLength() *
-          editor.getFontSize() * 1.4 > $('#' + pane).height()) {
+      var session = editor.getSession();
+      var long = (session.getLength() * big.height > $('#' + pane).height());
+      if (!long) {
+        // Scan for wrapped lines.
+        for (var j = 0; j < session.getLength(); ++j) {
+          if (session.getRowLength(j) > 1) {
+            long = true;
+            break;
+          }
+        }
+      }
+      if (long) {
         editor.setFontSize(16);
-        $('.editor').css({fontWeight: 500, lineHeight: '119%'});
+        $('#' + pane + ' .editor').css({fontWeight: 500, lineHeight: '119%'});
       }
     }
     if (!paneState.dirtied) {
@@ -1395,7 +1424,7 @@ function setPaneEditorText(pane, text, filename) {
   if (long) {
     editor.gotoLine(0);
   } else {
-    editor.gotoLine(lines, editor.getSession().getLine(lines - 1).length);
+    editor.gotoLine(editor.getSession().getLength() - 1, 0);
   }
   setPrimaryFocus();
   editor.on('focus', function() {


### PR DESCRIPTION
The old heuristic choses a giant font when the student's
program is short enough to fit without vertical scrolling, but
it does not pay attention to horizontal wrapping.

This commit adds logic to be aware of the width of the text:
if it is wider than the window to begin with, or if later some
changes cause wrapping to occur, the small font is used.
