### PR TITLE
Remove newlines from pencil code BODY element.

### DIFF
--- a/site/top/src/editor-view.js
+++ b/site/top/src/editor-view.js
@@ -895,8 +895,8 @@ function wrapTurtle(text) {
   return (
 '<!doctype html>\n<html>\n<head>\n<script src="http://' +
 window.pencilcode.domain + '/turtlebits.js"><\057script>\n' +
-'</head>\n<body>\n<script type="text/coffeescript">\neval $.turtle()\n\n' +
-text + '\n<\057script>\n</body>\n</html>\n');
+'</head>\n<body><script type="text/coffeescript">\neval $.turtle()\n\n' +
+text + '\n<\057script></body></html>');
 }
 
 function modifyForPreview(text, filename, targetUrl) {

--- a/site/wsgi/load.py
+++ b/site/wsgi/load.py
@@ -239,8 +239,8 @@ def application(env, start_response):
     return (
     '<!doctype html>\n<html>\n<head>\n' +
     '<script src="http://%s/turtlebits.js"></script>\n' % (domain) +
-    '</head>\n<body>\n<script type="text/coffeescript">\neval $.turtle()\n\n' +
-    text + '\n</script>\n</body>\n</html>\n')
+    '</head>\n<body><script type="text/coffeescript">\neval $.turtle()\n\n' +
+    text + '\n</script></body></html>')
   
   if os.path.isfile(absfile):
     split = filename.rsplit('.', 1)


### PR DESCRIPTION
This change alters the boilerplate HTML wrapper for pencil
code programs so that newlines do not appear inside the body
text.  The reason is to allow exercises like this one:

http://jlhwths.pencilcode.net.dev/edit/pyramid

That exercise sets $('body').css { whiteSpace: 'pre' } in order to
old-fashioned simulate monospace formatting for text appended to
the body.  Without this change, flipping the body to 'pre' will
display a bunch of blank lines.  With this change, the body starts
nicely empty, with no extra newline or whitespace characters.
