### PR TITLE
Improve run-button feedback by adding 1ms delay.

### DIFF
--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -1100,7 +1100,7 @@ function runCodeAtPosition(position, code, filename) {
     if (m.running) {
       view.setPaneRunText(pane, code, filename, baseUrl);
     }
-  }, 0);
+  }, 1);
   if (code) {
     $.get('/log/' + filename + '?run=' +
         encodeURIComponent(code).replace(/%20/g, '+').replace(/%0A/g, '|')


### PR DESCRIPTION
When clicking on the run button, it flips to a "square" shape before running the program.  However, if the program begins by doing something that hangs, it the browser hasn't gotten a chance to redraw the screen to draw the "square" first, so it feels like nothing has happened.

By adding 1ms to the delay (instead of 0) before running user code, we give the browser a chance to do a redraw.  (With a 0ms delay, the redraw was working only intermittently.)  This way, even if the user program hangs, they can see that it's running, because the "square" is showing.
