### PR TITLE
Provide a standard ide object to libraries.

### DIFF
--- a/site/top/src/showturtle.js
+++ b/site/top/src/showturtle.js
@@ -1,6 +1,9 @@
 $.turtle();
 if (window.ide == null) try {
   window.ide = null;
+  // Propagate the ide variable from the parent window, if present.
+  // When running framed inside in the pencilcode ide, this object
+  // is set up by editor-debug.js.
   if (window.parent !== window && window.parent.ide &&
       $.isFunction(window.parent.ide.getEditorText)) {
     window.ide = window.parent.ide;


### PR DESCRIPTION
The ide object is used by metaprogramming libraries.  When the ide is present, it should be an object that provides getEditorText() and setEditorText() calls.  When the ide is not present, then ide == null.
