### PR TITLE
Bring frame.html in line with editor.html.

### DIFF
--- a/site/top/src/framed.html
+++ b/site/top/src/framed.html
@@ -22,12 +22,10 @@ document.write(
   '<link rel="stylesheet" type="text/css" href="//' +
   pencilcode.domain + '/editor.css">' +
   '<link rel="stylesheet" type="text/css" href="//' +
-  pencilcode.domain + '/lib/tooltipster/css/tooltipster.css">' +
-  '<script src="//' + pencilcode.domain + '/turtlebits.js"><' +
-  '/script>');
+  pencilcode.domain + '/lib/tooltipster/css/tooltipster.css">');
 </script>
 </head>
-<body id="pencilcode" class="framed">
+<body id="pencildoc" class="framed">
 <div id="overflow">
 <div id="overlay"></div>
 <div id="notification"><div><div></div></div></div>


### PR DESCRIPTION
The editor no longer needs to load turtlebits.js in the topmost window;
remove this.
