### PR TITLE
Discourage too-long usernames.

### DIFF
--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -597,12 +597,21 @@ function signUpAndSave() {
           info: 'Invalid username.'
         };
       }
-      if (username && (  // Discourage certain forms of usernames:
-          letterComplexity(username) <= 1 ||             // "aaaaa"
-          /(?:com|org|net|edu|mil)$/.test(username))) {  // "emailschooledu"
+      if (username && letterComplexity(username) <= 1) {
+        // Discourage users from choosing a username "aaaaaa".
         return {
           disable: true,
           info: 'Name "' + username + '" reserved.'
+        };
+      }
+      if (username && username.length >= 8 &&
+          /(?:com|org|net|edu|mil)$/.test(username)) {
+        // Discourage users from choosing a username that looks like
+        // an email address or domain name.
+        return {
+          disable: true,
+          info: 'Name should not end with "' +
+              username.substr(username.length - 3) + '".'
         };
       }
       if (state.username.length < 3) {

--- a/test/new_user.js
+++ b/test/new_user.js
@@ -172,7 +172,7 @@ describe('new user', function() {
     }, function(err, result) {
       assert.ifError(err);
       // The message should report that the password is wrong.
-      assert.equal('Name \"bobatmitedu\" reserved.', result.infotext);
+      assert.equal('Name should not end with "edu".', result.infotext);
       done();
     });
   });


### PR DESCRIPTION
Usernames longer than 20 chars look like they aren't mnemonic,
so discourage these longer names.

Also, discourage names that look like possible email addresses
(ending with a common domain suffix).
