### PR TITLE
HTML files should not automatically run.

### DIFF
--- a/site/top/src/filetype.js
+++ b/site/top/src/filetype.js
@@ -55,6 +55,10 @@ function modifyForPreview(text, filename, targetUrl, pragmasOnly, sScript) {
   if (mimeType && /^text\/x-pencilcode/.test(mimeType)) {
     text = wrapTurtle(text, pragmasOnly, sScript);
     mimeType = mimeType.replace(/\/x-pencilcode/, '/html');
+  } else if (pragmasOnly) {
+    // For now, we don't support inserting startup script in anything
+    // other than a pencil-code file.
+    return '';
   }
   if (!text) return '';
   if (mimeType && !/^text\/html/.test(mimeType)) {


### PR DESCRIPTION
Fix a bug introduced with the script-pragmas: HTML files should not
automatically run when viewed.
