### PR TITLE
Avoid window.location.hash due to FF inconsistency.

### DIFF
--- a/site/top/src/editor-main.js
+++ b/site/top/src/editor-main.js
@@ -1407,8 +1407,9 @@ function cookie(key, value, options) {
   var decode = function(s) {
      try {
         return decodeURIComponent(s.replace(/\+/g, ' '));
-     } catch(e) { }
-     return '';
+     } catch (e) {
+       return '';
+     }
   }
   var converted = function(s) {
     if (s.indexOf('"') === 0) {


### PR DESCRIPTION
This change fixes two things:
(1) Since Firefox oddly partially uri-decodes window.location.hash (and we depend on uncecoded values because we need to do full uri-decoding ourselves), we avoid window.location.hash in favor of splitting window.location.href at # manually.
(2) This had been cascading into decodeURI errors, which interrupted loading.  Now decodeURI is also protected by try/catch wherever it is called so that malformed hashes (or cookies, etc) should not prevent loading.
