### PR TITLE
Add the ability for an embedded pencilcode to bring up a 'save' dialog

### DIFF
--- a/site/top/editor.css
+++ b/site/top/editor.css
@@ -7,6 +7,7 @@ body {margin:0;padding:0;font:24px/28px "Lato";font-weight:700;overflow:hidden}
   border:none;background-color:white;box-shadow:0 0 7px black;color:black;
   border-radius:8px;font-family:inherit;font-size:18px;line-height:21px;
   padding:12px;font-weight:300;text-align:center;width:330px;overflow:hidden;}
+.framed #overlay .dialog{top:12px;}
 #overlay .prompt{padding:8px;font-weight:900;}
 #overlay .info{padding:3px;color:red;}
 #overlay .content{display:inline-block;padding:3px;}

--- a/site/top/lib/pencilcodeembed.js
+++ b/site/top/lib/pencilcodeembed.js
@@ -255,6 +255,11 @@
       return this.invokeRemote('beginRun', []);
     };
 
+    // brings up save UI
+    proto.save = function(filename) {
+      return this.invokeRemote('save', [filename]);
+    };
+
     // makes editor editable
     proto.setEditable = function() {
       return this.invokeRemote('setEditable', []);

--- a/site/top/src/editor-view.js
+++ b/site/top/src/editor-view.js
@@ -464,11 +464,16 @@ $('#filename').on('keypress keydown keyup input', function(e) {
   if (text == '') { sel.html('&nbsp;'); }
 });
 
+function fixTypedFilename(enteredtext) {
+  if (!enteredtext) { return enteredtext; }
+  return enteredtext.replace(/\s|\xa0|[^\w\/.-]/g, '')
+      .replace(/^\/*/, '').replace(/\/\/+/g, '/');
+}
+
 $('#filename').on('blur', function() {
   var sel = $('#filename');
   var enteredtext = sel.text();
-  var fixedtext = enteredtext.replace(/\s|\xa0|[^\w\/.-]/g, '')
-      .replace(/^\/*/, '').replace(/\/\/+/g, '/');
+  var fixedtext = fixTypedFilename(enteredtext);
   if (!fixedtext) {
     fixedtext = state.nameText;
   }
@@ -856,6 +861,9 @@ function showLoginDialog(opts) {
         'type="password" class="newpass"></div>'
       : '<div class="field">Password:<input ' +
         'type="password" class="password"></div>') +
+      (opts.rename ?
+        '<div class="field">Filename:<input class="rename" value="' +
+         opts.rename + '">' : '') +
     '</div><br>' +
     '<button class="ok">OK</button>' +
     '<button class="cancel">Cancel</button>';
@@ -866,7 +874,18 @@ function showLoginDialog(opts) {
         return false;
       }
     });
-
+    dialog.find('.rename').on('keypress', function(e) {
+      if (e.which >= 20 && e.which <= 127 && !/[-\._A-Za-z0-9\/]/.test(
+            String.fromCharCode(e.which))) {
+        return false;
+      }
+    }).on('keyup blur', function(e) {
+      var val = dialog.find('.rename').val();
+      var fixed = fixTypedFilename(val);
+      if (fixed != val) {
+        dialog.find('.rename').val(fixed);
+      }
+    });
     dialog.find('input:not([disabled])').eq(0).focus();
   }
   opts.onkeydown = function(e, dialog, state) {
@@ -890,6 +909,7 @@ function showLoginDialog(opts) {
       checkbox: dialog.find('.agreetoterms').prop('checked'),
       password: dialog.find('.password').val(),
       newpass: dialog.find('.newpass').val(),
+      rename: fixTypedFilename(dialog.find('.rename').val()),
     };
   }
 


### PR DESCRIPTION
Add the ability for an embedded pencilcode to bring up a 'save' dialog that allows signup.

Also, allow sign-up-save flow to rename the saved project.  Also treat
gymstage as a special account, so it goes into the signup flow on save.
