### PR TITLE
Add CORS header to devserver.

### DIFF
--- a/site/node/serverbase.js
+++ b/site/node/serverbase.js
@@ -22,6 +22,11 @@ exports.initialize = function(app) {
   console.log('using', process.env.NODE_ENV, 'mode, on port', process.env.PORT);
 };
 exports.initialize2 = function(app) {
+  app.use(function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    next();
+  });
+
   app.use(express.bodyParser());
 
   app.use('/save', function(req, res) {


### PR DESCRIPTION
Now that &lt;script src="/turtlebits.js" crossorigin="anonymous"&gt; has a cross-origin directive, the devserver won't work without an access-control-allow-origin header.  So this commit adds one.
