### PR TITLE
Sync multiple tabs using localStorage

### DIFF
--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -710,6 +710,25 @@ view.on('toggleblocks', function(p, useblocks) {
       view.getPaneEditorLanguage(p));
 });
 
+view.on('setLocalStorage', function(data) {
+  try {
+    localStorage.setItem('editorValue', JSON.stringify({
+      user: model.username,
+      path: modelatpos('left').filename,
+      value: data
+    }));
+  } catch (e) { }
+});
+
+view.on('getLocalStorage', function(data) {
+  try {
+    data = JSON.parse(data);
+    if(data.user == model.username && data.path == modelatpos('left').filename) {
+      view.setEditorTabSync(paneatpos('left'), data);
+    }
+  } catch (e) { }
+});
+
 function saveAction(forceOverwrite, loginPrompt, doneCallback) {
   if (nosaveowner()) {
     return;

--- a/content/src/view.js
+++ b/content/src/view.js
@@ -2078,6 +2078,8 @@ function setPaneEditorData(pane, doc, filename, useblocks) {
   setPrimaryFocus();
 
   window.addEventListener("storage", function(e) {
+    /* block mode needs to be set to change editor value */
+    setPaneEditorBlockMode(pane, true);
     dropletEditor.setValue_raw(localStorage.getItem('dropletEditorValue'));
   }, false);
 

--- a/content/src/view.js
+++ b/content/src/view.js
@@ -2077,6 +2077,10 @@ function setPaneEditorData(pane, doc, filename, useblocks) {
   var um = editor.getSession().getUndoManager();
   setPrimaryFocus();
 
+  window.addEventListener("storage", function(e) {
+    dropletEditor.setValue_raw(localStorage.getItem('dropletEditorValue'));
+  }, false);
+
   setupAceEditor(pane, mainContainer, editor,
     modeForMimeType(editorMimeType(paneState)), text);
   var session = editor.getSession();
@@ -2086,6 +2090,7 @@ function setPaneEditorData(pane, doc, filename, useblocks) {
     if (paneState.cleanLineCount != session.getLength()) {
       clearPaneEditorMarks(pane);
       fireEvent('changelines', [pane]);
+      localStorage.setItem('dropletEditorValue', dropletEditor.getValue());
     }
     fireEvent('delta', [pane]);
   });


### PR DESCRIPTION
So this is the basic code to sync code editor value across multiple tabs. One caveat is that apparently when 'Code mode' is enabled, i.e. 'Block mode' is disabled, then realtime changes do not sync across tabs. (the text can't redraw itself like blocks do). So I set the Code mode to go into Block mode whenever it receives a localStorage update. Probably the performance is taking a hit - handler is executing twice every keystroke, so I want to improve it.
While the local-storage wrapper isn't so big, it is a new module (2 months old) and doesn't seem to add much benefit as local storage is well supported in browsers. Safari in incognito mode doesn't support it. ( http://ponyfoo.com/articles/cross-tab-communication )