### PR TITLE
Upgrade node to v0.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ just apt-get install the packages.  Get and build the latest `node` and
 
 <pre>
 mkdir -p /tmp/nodejs && cd /tmp/nodejs
-wget -N http://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz
+wget -N http://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz
 tar xzvf node-*.tar.gz && cd `ls -rd node-v*`
 ./configure --prefix=$HOME/local
 make install
@@ -46,7 +46,7 @@ Zsh users should change `bashrc` to `zshrc` in the above code.
 
 <pre>
 mkdir -p /tmp/nodejs && cd /tmp/nodejs
-curl http://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz > node-latest.tar.gz
+curl http://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz > node-latest.tar.gz
 tar xzvf node-latest.tar.gz && cd `ls -rd node-v*`
 ./configure --prefix=$HOME/local
 make install

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ The Ubuntu and Debian packages for node.js are pretty old, so don't
 just apt-get install the packages.  Get and build the latest `node` and
 `npm` and `grunt` binaries as follows:
 
-(For Linux:)s
+(For Linux:)
 
 <pre>
 mkdir -p /tmp/nodejs && cd /tmp/nodejs
 wget -N http://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz
-tar xzvf node-*.tar.gz && cd `ls -rd node-v*`
+tar xzvf node-*.tar.gz && cd `ls -d node-v*`
 ./configure --prefix=$HOME/local
 make install
 echo 'export PATH=$HOME/local/bin:$PATH' &gt;&gt; ~/.bashrc

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "latest",
     "dynamic.io": "latest",
     "express": "latest",
-    "fs-ext": "latest",
+    "fs-ext": "^0.4.4",
     "fs-extra": "latest",
     "http-proxy": "latest",
     "log-timestamp": "latest",


### PR DESCRIPTION
Following changes were made:
1. All dependencies except older versions of fs-ext are compatible with node v0.12.2. `npm install` for some reason didn't install the most recent version of fs-ext (0.4.4) in my system so I changed package.json to take care of that.
2. I updated the node source code link in the readme. Also `ls -rd`, on systems I checked, prints the tar.gz file first and then the uncompressed tar folder. Due to this ``cd `ls -rd node-v*` `` didn't work properly so I removed the `-r` option. If this seems wrong, we can just change the whole command to `cd node-v0.12.2`    

  