### PR TITLE
Add hideToggleButton to pencilcodeembed.js

### DIFF
--- a/content/lib/pencilcodeembed.js
+++ b/content/lib/pencilcodeembed.js
@@ -48,6 +48,7 @@
 //    console.log('load complete');
 //    pce.hideEditor();
 //    pce.hideMiddleButton();
+//    pce.hideToggleButton();
 //    pce.setReadOnly();
 //    pce.showNotification('Pay attention to the Turtle!');
 //    setTimeout(function(){
@@ -308,12 +309,12 @@
       return this.invokeRemote('showMiddleButton', []);
     };
 
-    // hides middle button
+    // hides toggle button
     proto.hideToggleButton = function() {
       return this.invokeRemote('hideToggleButton', []);
     };
 
-    // shows middle button
+    // shows toggle button
     proto.showToggleButton = function() {
       return this.invokeRemote('showToggleButton', []);
     };

--- a/content/lib/pencilcodeembed.js
+++ b/content/lib/pencilcodeembed.js
@@ -308,6 +308,16 @@
       return this.invokeRemote('showMiddleButton', []);
     };
 
+    // hides middle button
+    proto.hideToggleButton = function() {
+      return this.invokeRemote('hideToggleButton', []);
+    };
+
+    // shows middle button
+    proto.showToggleButton = function() {
+      return this.invokeRemote('showToggleButton', []);
+    };
+
     // show butter bar notification
     proto.showNotification = function(message) {
       return this.invokeRemote('showNotification', [message]);

--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -2071,6 +2071,12 @@ $(window).on('message', function(e) {
       view.canShowMiddleButton = true;
       view.showMiddleButton('run');
       break;
+    case 'hideMiddleButton':
+      view.showToggleButton(false);
+      break;
+    case 'showMiddleButton':
+      view.showToggleButton(true);
+      break;
     case 'setEditable':
       view.setPaneEditorReadOnly(paneatpos('left'), false);
       break;

--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -2071,10 +2071,10 @@ $(window).on('message', function(e) {
       view.canShowMiddleButton = true;
       view.showMiddleButton('run');
       break;
-    case 'hideMiddleButton':
+    case 'hideToggleButton':
       view.showToggleButton(false);
       break;
-    case 'showMiddleButton':
+    case 'showToggleButton':
       view.showToggleButton(true);
       break;
     case 'setEditable':

--- a/content/src/editor.less
+++ b/content/src/editor.less
@@ -1104,7 +1104,7 @@ body#pencildoc #diigolet-csm {
   right: -80px;
 }
 
-.textonly .blocktoggle {
+.textonly .blocktoggle, .notoggletab .texttoggle, .notoggletab .blocktoggle {
   display: none;
 }
 

--- a/content/src/view.js
+++ b/content/src/view.js
@@ -181,6 +181,9 @@ window.pencilcode.view = {
       $('#middle').hide();
     }
   },
+  showToggleButton: function(enable) {
+    $('body').toggleClass('notoggletab', !enable);
+  },
   // Sets editable name.
   setNameText: function(s) {
     state.nameText = s;

--- a/test/framed_embed.js
+++ b/test/framed_embed.js
@@ -206,6 +206,9 @@ describe('framed embed', function() {
       pco.hideMiddleButton();
       pco.showMiddleButton();
 
+      pco.hideToggleButton();
+      pco.showToggleButton();
+
       pco.setReadOnly();
       pco.setEditable();
 


### PR DESCRIPTION
This allows embedders to hide the button that toggles between block mode and text mode.