### PR TITLE
Watch `less` files and auto-compile them

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,6 +234,11 @@ module.exports = function(grunt) {
           'server/*.json',
           'content/src/filetype.js' ],
         options: { spawn: false }
+      },
+      styles: {
+        files: ['content/src/*.less'],
+        tasks: ['less'],
+        options: { spawn: false }
       }
     },
     copy: {


### PR DESCRIPTION
Make `watch` watch `less` files also, and auto-compiles it when there is any change in the `less` files. This makes it very convenient for editing `less` files, as we don't need to manually run another `less` task. It completes instantly as so far we only have two simple `less` files to compile. 

Example output:
```
Running "watch" task
Waiting...
>> File "content/src/editor.less" changed.

Running "less:all" (less) task
File content/welcome.css created
File content/editor.css created

Running "watch" task
Completed in 0.444s at Sat May 30 2015 11:53:49 GMT+0800 (SGT) - Waiting...
>> File "content/src/editor.less" changed.

Running "less:all" (less) task
File content/welcome.css created
File content/editor.css created

Running "watch" task
Completed in 0.229s at Sat May 30 2015 11:54:36 GMT+0800 (SGT) - Waiting...
```
