### PR TITLE
Fix typo in `save.js`

### DIFF
--- a/server/save.js
+++ b/server/save.js
@@ -143,7 +143,7 @@ exports.handleSave = function(req, res, app) {
 
       var absSourceFile = utils.makeAbsolute(sourcefile, app);
       var absSourceThumb = utils.getAbsThumbPath(sourcefile, app);
-      var sourceThumbExists = fs.existsSync(path.dirname(absSourceThumb));
+      var sourceThumbExists = fs.existsSync(absSourceThumb);
       if (!fs.existsSync(absSourceFile)) {
         utils.errorExit('Source file does not exist. ' + sourcefile);
       }


### PR DESCRIPTION
I made a typo in `save.js`. I should check whether the thumb exists, but not whether the `.thumbs` folder exists. That would cause an wrong notification when trying to move/rename a file without a thumb, but the `.thumbs` directory exists, (i.e. other files in this directory has thumbs). 

Simply check the existence of the thumb instead of the `.thumbs` folder fixes the problem. 