### PR TITLE
Fix #143 (syntax error highlighting)

### DIFF
--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -1806,10 +1806,12 @@ function instrumentCode(code, language) {
       debug.setSourceMap(result.v3SourceMap);
       code = result.js;
     } catch (err) {
-      // If there was an error while instrumenting, just return non-instrumented
-      // JavaScript.
-      console.warn("Error during instrumentation! Debugger will be disabled for this run. Error was:\n" + err);
-      code = icedCoffeeScript.compile(code, { bare: true });
+      // An error here means that either the user's code has a syntax error, or
+      // pencil-tracer has a bug. Returning false here means the user's code
+      // will run directly, without the debugger, and then if there's a syntax
+      // error it will be displayed to them, and if it's a pencil-tracer bug,
+      // their code will still run but with the debugger disabled.
+      return false;
     }
   }
   return code;

--- a/content/src/debug.js
+++ b/content/src/debug.js
@@ -434,7 +434,7 @@ function editorLineNumberForError(error) {
   if (!frame) {
     if (error instanceof targetWindow.SyntaxError) {
       if (error.location) {
-        return error.location.first_line;
+        return error.location.first_line - 2;
       }
     }
     return null;

--- a/content/src/filetype.js
+++ b/content/src/filetype.js
@@ -178,8 +178,11 @@ function wrapTurtle(doc, domain, pragmasOnly, setupScript, instrumenter) {
   if (instrumenter) {
     // Instruments the code for debugging, always producing javascript.
     var language = /javascript/i.test(maintype) ? 'javascript' : 'coffeescript';
-    text = instrumenter(text, language);
-    maintype = 'text/javascript';
+    var newText = instrumenter(text, language);
+    if (newText !== false) {
+      text = newText;
+      maintype = 'text/javascript';
+    }
   }
   var mainscript = '<script type="' + maintype + '">\n' + seeline;
   if (!pragmasOnly) {


### PR DESCRIPTION
#143

This gets the old behaviour back of highlighting syntax errors. When instrumentation fails (which can happen either from a user's syntax error or from a bug in pencil-tracer), it now tries to run the user's original code directly in a `<script type="text/coffeescript">` tag. Then if their code has a syntax error, it will be displayed, and if not, it will run fine, just without the debugger.