### PR TITLE
Make sure instrumented code is wrapped in a closure

### DIFF
--- a/content/src/filetype.js
+++ b/content/src/filetype.js
@@ -169,7 +169,6 @@ function wrapTurtle(doc, domain, pragmasOnly, setupScript, instrumenter) {
     maintype = doc.meta.type;
   }
   var seeline = '\n\n';
-  var trailing = '\n';
   if (/javascript/.test(maintype)) {
     seeline = 'eval(this._start_ide_js_);\n\n';
   } else if (/coffeescript/.test(maintype)) {
@@ -184,11 +183,20 @@ function wrapTurtle(doc, domain, pragmasOnly, setupScript, instrumenter) {
       maintype = 'text/javascript';
     }
   }
-  var mainscript = '<script type="' + maintype + '">\n' + seeline;
+  var mainscript = '<script type="' + maintype + '">\n';
+  if (/javascript/.test(maintype)) {
+    // Wrap javascript in a closure (coffeescript does this automatically).
+    mainscript += '(function(){\n';
+  }
+  mainscript += seeline; // seeline must execute inside the closure.
   if (!pragmasOnly) {
     mainscript += text;
   }
-  mainscript += trailing + '<\057script>';
+  if (/javascript/.test(maintype)) {
+    // Close the wrapped closure.
+    mainscript += '\n})();'
+  }
+  mainscript += '\n<\057script>';
   var result = (
     prefix.join('\n') +
     html +

--- a/content/src/filetype.js
+++ b/content/src/filetype.js
@@ -169,34 +169,36 @@ function wrapTurtle(doc, domain, pragmasOnly, setupScript, instrumenter) {
     maintype = doc.meta.type;
   }
   var seeline = '\n\n';
-  if (/javascript/.test(maintype)) {
+  var originalLanguage = null;
+  if (/javascript/i.test(maintype)) {
     seeline = 'eval(this._start_ide_js_);\n\n';
+    originalLanguage = 'javascript';
   } else if (/coffeescript/.test(maintype)) {
     seeline = 'eval(this._start_ide_cs_);\n\n';
+    originalLanguage = 'coffeescript';
   }
+  var instrumented = false;
   if (instrumenter) {
     // Instruments the code for debugging, always producing javascript.
-    var language = /javascript/i.test(maintype) ? 'javascript' : 'coffeescript';
-    var newText = instrumenter(text, language);
+    var newText = instrumenter(text, originalLanguage);
     if (newText !== false) {
       text = newText;
       maintype = 'text/javascript';
+      instrumented = true;
     }
   }
-  var mainscript = '<script type="' + maintype + '">\n';
-  if (/javascript/.test(maintype)) {
-    // Wrap javascript in a closure (coffeescript does this automatically).
-    mainscript += '(function(){\n';
-  }
-  mainscript += seeline; // seeline must execute inside the closure.
+  var mainscript = seeline;
   if (!pragmasOnly) {
     mainscript += text;
   }
-  if (/javascript/.test(maintype)) {
-    // Close the wrapped closure.
-    mainscript += '\n})();'
+  if (instrumented && originalLanguage === 'coffeescript') {
+    // Wrap instrumented + compiled coffeescript in a closure, since that's how
+    // coffeescript programs are normally compiled. (We didn't compile it to be
+    // in a closure because the seeline needs to be in the same scope as the
+    // user's program.)
+    mainscript = '(function(){\n' + mainscript + '\n})();';
   }
-  mainscript += '\n<\057script>';
+  mainscript = '<script type="' + maintype + '">\n' + mainscript + '\n<\057script>';
   var result = (
     prefix.join('\n') +
     html +

--- a/test/storage_json.js
+++ b/test/storage_json.js
@@ -377,7 +377,7 @@ describe('test of server json apis', function() {
   });
   it('loads a file from home', function(done) {
     get('zzz', '/home/jsfile', 'utf8', function(s, data) {
-      assert(/<script type="text\/javascript">[^<]*alert\("hello"\);[\s},0);]*<\/script>/.test(data), data);
+      assert(/<script type="text\/javascript">[^<]*alert\("hello"\);[\s},0();]*<\/script>/.test(data), data);
       done();
     });
   });


### PR DESCRIPTION
Fixes: #146

As well as wrapping instrumented/compiled coffeescript in a closure, this also wraps all javascript programs in a closure. The seejs debugger still works, as it is eval'd inside the wrapped closure.