### PR TITLE
BugFix - No palette with file extension

### DIFF
--- a/content/src/view.js
+++ b/content/src/view.js
@@ -1548,7 +1548,7 @@ function dropletModeForMimeType(mimeType) {
 }
 
 function paletteForPane(paneState, selfname) {
-  var mimeType = editorMimeType(paneState),
+  var mimeType = editorMimeType(paneState).replace(/;.*$/, ''),
       basePalette = paneState.palette;
   if (!basePalette) {
     if (mimeType == 'text/x-pencilcode' || mimeType == 'text/coffeescript') {
@@ -1558,7 +1558,7 @@ function paletteForPane(paneState, selfname) {
         mimeType == 'application/x-javascript') {
       basePalette = palette.JAVASCRIPT_PALETTE;
     }
-    if (mimeType.replace(/;.*$/, '') == 'text/html') {
+    if (mimeType == 'text/html') {
       basePalette = palette.HTML_PALETTE;
     }
   }


### PR DESCRIPTION
If you edit a file where mimeType is `text/<format>;...`
even if format is coffeescript or javascript, the palette didn't show up eg: (http://saksham.pencilcode.net/edit/test.js)
Fixes that bug by removing the part after `;...` in mimetype.