### PR TITLE
Switch palette on file rename

### DIFF
--- a/content/src/view.js
+++ b/content/src/view.js
@@ -2908,6 +2908,7 @@ function noteNewFilename(pane, filename) {
     paneState.dropletEditor.setMode(
         dropletModeForMimeType(visibleMimeType),
         dropletOptionsForMimeType(visibleMimeType));
+    paneState.dropletEditor.setPalette(paletteForPane(paneState));
     paneState.editor.getSession().setMode(modeForMimeType(visibleMimeType));
     if (!mimeTypeSupportsBlocks(visibleMimeType)) {
       setPaneEditorBlockMode(pane, false);


### PR DESCRIPTION
On changing a filename, the mode changes(if required), but not the palette.
To  reproduce create a file (say `bugtest`) then rename it to `bugtest.html`
This should change the palette to HTML, but it doesn't.
This fixes the bug.