### PR TITLE
HTML Palette modifications

### DIFF
--- a/content/src/palette.js
+++ b/content/src/palette.js
@@ -727,11 +727,11 @@ module.exports = {
           block: "<head>\n  \n</head>",
           title: "Represents a collection of metadata"
         }, {
+          block: "<body>\n  \n</body>",
+          title: "Main content of the document"
+        }, {
           block: "<title></title>",
           title: "Document's title or name"
-        }, {
-          block: "<base href=\"\" />",
-          title: "Base URL/target for all relative URLs in a document"
         }, {
           block: "<link rel=\"\" href=\"\" />",
           title: "Link between a document and an external resource"
@@ -747,42 +747,6 @@ module.exports = {
         }
       ]
     }, {
-      name: "Sections",
-      color: "orange",
-      blocks: [
-        {
-          block: "<body>\n  \n</body>",
-          title: "Main content of the document"
-        }, {
-          block: "<article>\n  \n</article>",
-          title: "Independent, self-contained content"
-        }, {
-          block: "<section>\n  \n</section>",
-          title: "Generic section of a document or application"
-        }, {
-          block: "<nav>\n  \n</nav>",
-          title: "Set of navigation links"
-        }, {
-          block: "<aside>\n  \n</aside>",
-          title: "Content aside from the content it is placed in"
-        }, {
-          block: "<h1></h1>",
-          title: "Heading for its section - Can use h1..h6 for different sizes"
-        }, {
-          block: "<hgroup>\n  \n</hgroup>",
-          title: "Group of headings h1-h6"
-        }, {
-          block: "<header>\n  \n</header>",
-          title: "Group of introductory or navigational aids"
-        }, {
-          block: "<footer>\n  \n</footer>",
-          title: "Footer for a document or section"
-        }, {
-          block: "<address>\n  \n</address>",
-          title: "Contact information for the author/owner"
-        }
-      ]
-    }, {
       name: "Grouping",
       color: "purple",
       blocks: [
@@ -790,20 +754,20 @@ module.exports = {
           block: "<p>\n  \n</p>",
           title: "Represents a paragraph"
         }, {
+          block: "<h3></h3>",
+          title: "Heading for its section - Can use h1..h6 for different sizes"
+        }, {
           block: "<hr />",
           title: "Paragraph-level thematic break"
         }, {
-          block: "<pre>\n  \n</pre>",
-          title: "Block of preformatted text"
+          block: "<div>\n  \n</div>",
+          title: "Defines a division"
         }, {
-          block: "<blockquote>\n  \n</blockquote>",
-          title: "Section that is quoted from another source"
-        }, {
-          block: "<ol>\n  \n</ol>",
-          title: "Ordered list"
+          block: "<span></span>",
+          title: "Group inline-elements"
         }, {
           block: "<ul>\n  \n</ul>",
-          title: "Unordered list"
+          title: "Unordered list - Use 'ol' for ordered list"
         }, {
           block: "<li></li>",
           title: "List item"
@@ -816,84 +780,18 @@ module.exports = {
         }, {
           block: "<dd></dd>",
           title: "Description of a term"
-        }, {
-          block: "<figure>\n  \n</figure>",
-          title: "Self-contained content, like illustrations, diagrams, photos, code listings, etc"
-        }, {
-          block: "<figcaption></figcaption>",
-          title: "Defines a caption for a <figure> element"
-        }, {
-          block: "<main>\n  \n</main>",
-          title: "Container for the dominant contents of another element"
-        }, {
-          block: "<div>\n  \n</div>",
-          title: "Defines a division"
         }
       ]
     }, {
-      name: "Text",
+      name: "Content",
       color: "lightgreen",
       blocks: [
         {
           block: "<a href=\"\"></a>",
           title: "Defines a hyperlink, which is used to link from one page to another"
         }, {
-          block: "<em></em>",
-          title: "Stress emphasis of its contents"
-        }, {
-          block: "<strong></strong>",
-          title: "Strong importance, seriousness, or urgency for its contents"
-        }, {
-          block: "<small></small>",
-          title: "Side comments such as small print"
-        }, {
-          block: "<s></s>",
-          title: "Contents that are no longer accurate/relevant"
-        }, {
-          block: "<cite></cite>",
-          title: "Title of a work"
-        }, {
-          block: "<q></q>",
-          title: "Short quotation"
-        }, {
-          block: "<dfn></dfn>",
-          title: "Defining instance of a term"
-        }, {
-          block: "<abbr title=\"\"></abbr>",
-          title: "Abbreviation or acronym, optionally with its expansion"
-        }, {
-          block: "<ruby>\n  \n</ruby>",
-          title: "Ruby annotation(small extra text, attached to the main text to indicate the pronunciation or meaning of the corresponding characters)"
-        }, {
-          block: "<rt></rt>",
-          title: "Marks the ruby text component of a ruby annotation"
-        }, {
-          block: "<rp></rp>",
-          title: "Provide parentheses or other content around a ruby text"
-        }, {
-          block: "<data value=\"\"></data>",
-          title: "Represents its contents, along with a machine-readable form of those contents in the value attribute"
-        }, {
-          block: "<time datetime=\"\"></time>",
-          title: "Human-readable date/time"
-        }, {
-          block: "<code></code>",
-          title: "Fragment of computer code"
-        }, {
-          block: "<var></var>",
-          title: "Variable"
-        }, {
-          block: "<samp></samp>",
-          title: "Sample or quoted output from another program"
-        }, {
-          block: "<kbd></kbd>",
-          title: "User input (typically keyboard input)"
-        }, {
-          block: "<sub></sub>",
-          title: "Subscript"
-        }, {
-          block: "<sup></sup>",
-          title: "Superscript"
+          block: "<img src=\"\" alt=\"\" />",
+          title: "Image"
         }, {
           block: "<i></i>",
           title: "Italic"
@@ -904,107 +802,35 @@ module.exports = {
           block: "<u></u>",
           title: "Underline"
         }, {
-          block: "<mark></mark>",
-          title: "Marked text"
+          block: "<sub></sub>",
+          title: "Subscript"
         }, {
-          block: "<bdi></bdi>",
-          title: "Bi-directional Isolation"
-        }, {
-          block: "<bdo dir=\"\">\n  \n</bdo>",
-          title: "Bi-Directional Override"
-        }, {
-          block: "<span></span>",
-          title: "Group inline-elements"
+          block: "<sup></sup>",
+          title: "Superscript"
         }, {
           block: "<br />",
           title: "Line break"
         }, {
-          block: "<wbr />",
-          title: "Line break opportunity"
-        }, {
-          block: "text",
-          title: "Text content"
-        }
-      ]
-    }, {
-      name: "Other",
-      color: "pink",
-      blocks: [
-        {
-          block: "<ins></ins>",
-          title: "Addition to the document"
-        }, {
-          block: "<del></del>",
-          title: "Removal from a document"
-        }, {
-          block: "<details>\n  \n</details>",
-          title: "Additional details that the user can view or hide on demand"
-        }, {
-          block: "<summary></summary>",
-          title: "Visible Heading of a <details> element"
-        }, {
-          block: "<menu>\n  \n</menu>",
-          title: "List/menu of commands"
-        }, {
-          block: "<menuitem></menuitem>",
-          title: "Command/menuitem inside a menu"
-        }, {
-          block: "<dialog open></dialog>",
-          title: "Dialog box or window"
-        }, {
-          block: "<noscript></noscript>",
-          title: "Alternate content for users that have disabled scripts"
-        }, {
-          block: "<template>\n  \n</template>",
-          title: "Declare fragments of HTML that can be cloned and inserted in the document by script"
-        }, {
-          block: "<canvas></canvas>",
-          title: "Draw graphics, on the fly, via scripting"
-        }, {
-          block: "<svg>\n  \n</svg>",
-          title: "Define graphics for the Web"
-        }, {
-          block: "<frameset cols=\"\">\n  \n</frameset>",
-          title: "Holds one or more <frame> elements each of which contains a separate document"
-        }
-      ]
-    }, {
-      name: "Embedded",
-      color: "teal",
-      blocks: [
-        {
-          block: "<img src=\"\" alt=\"\" />",
-          title: "Image"
-        }, {
           block: "<iframe>\n  \n</iframe>",
           title: "Nested browsing context"
         }, {
-          block: "<embed src=\"\" />",
-          title: "Integration point for an external (typically non-HTML) application or interactive content"
+          block: "<noscript></noscript>",
+          title: "Alternate content for users that have disabled scripts"
+        }
+      ]
+    }, {
+      name: "Sections",
+      color: "orange",
+      blocks: [
+        {
+          block: "<article>\n  \n</article>",
+          title: "Independent, self-contained content"
         }, {
-          block: "<object data=\"\">\n  \n</object>",
-          title: "Embedded object within an HTML document"
+          block: "<section>\n  \n</section>",
+          title: "Generic section of a document or application"
         }, {
-          block: "<param name=\"\" value=\"\" />",
-          title: "Parameters for plugins invoked by <object> elements"
-        }, {
-          block: "<video width=\"\" height=\"\" controls>\n  \n</video>",
-          title: "Playing videos or movies, and audio files with captions"
-        }, {
-          block: "<audio controls>\n  \n</audio>",
-          title: "Sound or audio stream"
-        }, {
-          block: "<source src=\"\" type=\"\" />",
-          title: "Specify multiple alternative media resources for media elements"
-        }, {
-          block: "<track src=\"\" />",
-          title: "Explicit external timed text tracks for media elements"
-        }, {
-          block: "<map name=\"\">\n  \n</map>",
-          title: "Define a client-side image-map(image with clickable areas)"
-        }, {
-          block: "<area shape=\"\" href=\"\" />",
-          title: "Area inside an image-map"
+          block: "<nav>\n  \n</nav>",
+          title: "Set of navigation links"
         }
       ]
     }, {
@@ -1014,24 +840,6 @@ module.exports = {
         {
           block: "<table>\n  \n</table>",
           title: "Defines a table"
-        }, {
-          block: "<caption></caption>",
-          title: "Table Caption"
-        }, {
-          block: "<colgroup>\n  \n</colgroup>",
-          title: "Group of 1 or more columns"
-        }, {
-          block: "<col style=\"\"/>",
-          title: "Column properties for a single column"
-        }, {
-          block: "<tbody>\n  \n</tbody>",
-          title: "Body of a table"
-        }, {
-          block: "<thead>\n  \n</thead>",
-          title: "Table header"
-        }, {
-          block: "<tfoot>\n  \n</tfoot>",
-          title: "Table footer"
         }, {
           block: "<tr>\n  \n</tr>",
           title: "Row in a table"
@@ -1054,8 +862,11 @@ module.exports = {
           block: "<input type=\"\" />",
           title: "Input field where user can enter data"
         }, {
+          block: "<textarea>\n  \n</textarea>",
+          title: "Multi-line text input"
+        }, {
           block: "<label for=\"\"></label>",
-          title: "Label for an <input> element"
+          title: "Label for an input element"
         }, {
           block: "<button></button>",
           title: "Clickable button"
@@ -1063,35 +874,12 @@ module.exports = {
           block: "<select>\n  \n</select>",
           title: "Drop-down list"
         }, {
-          block: "<option value=\"\"></option>",
+          block: "<option></option>",
+          expansion: "<option value=\"\"></option>",
           title: "Option in a <select> list"
-        }, {
-          block: "<optgroup>\n  \n</optgroup>",
-          title: "Group related options in a <select> list"
-        }, {
-          block: "<datalist>\n  \n</datalist>",
-          title: "Pre-defined list of inputs for <input> element with autocomplete"
-        }, {
-          block: "<textarea>\n  \n</textarea>",
-          title: "Multi-line text input"
-        }, {
-          block: "<keygen />",
-          title: "Key-pair generator field"
-        }, {
-          block: "<output for=\"\"></output>",
-          title: "Results of a calculation"
-        }, {
-          block: "<progress value=\"\" max=\"\"></progress>",
-          title: "Progress of a task"
-        }, {
-          block: "<meter value=\"\"></meter>",
-          title: "Scalar measurement within a known range, or a fractional value"
         }, {
           block: "<fieldset>\n  \n</fieldset>",
           title: "Group related items in a form"
-        }, {
-          block: "<legend></legend>",
-          title: "Caption for a <fieldset> element"
         }
       ]
     }

--- a/content/src/palette.js
+++ b/content/src/palette.js
@@ -721,13 +721,16 @@ module.exports = {
           block: "<!DOCTYPE html>",
           title: "Defines document type"
         }, {
-          block: "<html>\n  \n</html>",
+          block: "<html></html>",
+          expansion: "<html>\n  <head>\n    \n  </head>\n  <body>\n    \n  </body>\n</html>",
           title: "Root of an HTML document"
         }, {
-          block: "<head>\n  \n</head>",
+          block: "<head></head>",
+          expansion: "<head>\n  \n</head>",
           title: "Represents a collection of metadata"
         }, {
-          block: "<body>\n  \n</body>",
+          block: "<body></body>",
+          expansion: "<body>\n  \n</body>",
           title: "Main content of the document"
         }, {
           block: "<title></title>",
@@ -739,10 +742,12 @@ module.exports = {
           block: "<meta charset=\"\" />",
           title: "Metadata about the HTML document"
         }, {
-          block: "<style>\n  \n</style>",
+          block: "<style></style>",
+          expansion: "<style>\n  \n</style>",
           title: "Define style information"
         }, {
-          block: "<script>\n  \n</script>",
+          block: "<script></script>",
+          expansion: "<script>\n  \n</script>",
           title: "Define a client-side script, such as a JavaScript"
         }
       ]
@@ -751,7 +756,8 @@ module.exports = {
       color: "purple",
       blocks: [
         {
-          block: "<p>\n  \n</p>",
+          block: "<p></p>",
+          expansion: "<p>\n  \n</p>",
           title: "Represents a paragraph"
         }, {
           block: "<h3></h3>",
@@ -760,19 +766,22 @@ module.exports = {
           block: "<hr />",
           title: "Paragraph-level thematic break"
         }, {
-          block: "<div>\n  \n</div>",
+          block: "<div></div>",
+          expansion: "<div>\n  \n</div>",
           title: "Defines a division"
         }, {
           block: "<span></span>",
           title: "Group inline-elements"
         }, {
-          block: "<ul>\n  \n</ul>",
+          block: "<ul></ul>",
+          expansion: "<ul>\n  \n</ul>",
           title: "Unordered list - Use 'ol' for ordered list"
         }, {
           block: "<li></li>",
           title: "List item"
         }, {
-          block: "<dl>\n  \n</dl>",
+          block: "<dl></dl>",
+          expansion: "<dl>\n  \n</dl>",
           title: "Description list"
         }, {
           block: "<dt></dt>",
@@ -793,6 +802,10 @@ module.exports = {
           block: "<img src=\"\" alt=\"\" />",
           title: "Image"
         }, {
+          block: "<iframe></iframe>",
+          expansion: "<iframe>\n  \n</iframe>",
+          title: "Nested browsing context"
+        }, {
           block: "<i></i>",
           title: "Italic"
         }, {
@@ -810,12 +823,6 @@ module.exports = {
         }, {
           block: "<br />",
           title: "Line break"
-        }, {
-          block: "<iframe>\n  \n</iframe>",
-          title: "Nested browsing context"
-        }, {
-          block: "<noscript></noscript>",
-          title: "Alternate content for users that have disabled scripts"
         }
       ]
     }, {
@@ -823,13 +830,16 @@ module.exports = {
       color: "orange",
       blocks: [
         {
-          block: "<article>\n  \n</article>",
+          block: "<article></article>",
+          expansion: "<article>\n  \n</article>",
           title: "Independent, self-contained content"
         }, {
-          block: "<section>\n  \n</section>",
+          block: "<section></section>",
+          expansion: "<section>\n  \n</section>",
           title: "Generic section of a document or application"
         }, {
-          block: "<nav>\n  \n</nav>",
+          block: "<nav></nav>",
+          expansion: "<nav>\n  \n</nav>",
           title: "Set of navigation links"
         }
       ]
@@ -838,10 +848,12 @@ module.exports = {
       color: "indigo",
       blocks: [
         {
-          block: "<table>\n  \n</table>",
+          block: "<table></table>",
+          expansion: "<table>\n  \n</table>",
           title: "Defines a table"
         }, {
-          block: "<tr>\n  \n</tr>",
+          block: "<tr></tr>",
+          expansion: "<tr>\n  \n</tr>",
           title: "Row in a table"
         }, {
           block: "<td></td>",
@@ -856,13 +868,15 @@ module.exports = {
       color: "deeporange",
       blocks: [
         {
-          block: "<form action=\"\">\n  \n</form>",
+          block: "<form action=\"\"></form>",
+          expansion: "<form action=\"\">\n  \n</form>",
           title: "Create an HTML form"
         }, {
           block: "<input type=\"\" />",
           title: "Input field where user can enter data"
         }, {
-          block: "<textarea>\n  \n</textarea>",
+          block: "<textarea></textarea>",
+          expansion: "<textarea>\n  \n</textarea>",
           title: "Multi-line text input"
         }, {
           block: "<label for=\"\"></label>",
@@ -871,15 +885,13 @@ module.exports = {
           block: "<button></button>",
           title: "Clickable button"
         }, {
-          block: "<select>\n  \n</select>",
+          block: "<select></select>",
+          expansion: "<select>\n  \n</select>",
           title: "Drop-down list"
         }, {
           block: "<option></option>",
           expansion: "<option value=\"\"></option>",
           title: "Option in a <select> list"
-        }, {
-          block: "<fieldset>\n  \n</fieldset>",
-          title: "Group related items in a form"
         }
       ]
     }


### PR DESCRIPTION
Includes several palette modifications including
- Reduced palette sized (include only the common ones)
- Reorder blocks in blocks based on use case and frequency
- Blocks appear inline in the palette but expand when dragged out.
(The above modifications were done based on analysis of over 10GB of webpages, whose results can be found at - https://gist.github.com/sakagg/772435aa9d76745c1ba4)

One thing that is significantly different is the `<html>` block.
By default when dragging it out, it automatically includes a `<head>` and a `<body>` tag.
Let me know if you want this behavior to be changed.