### PR TITLE
Fix pickblock logging, and add a test that verifies it.

### DIFF
--- a/content/lib/droplet.js
+++ b/content/lib/droplet.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2015 Anthony Bau.
  * MIT License.
  *
- * Date: 2015-07-20
+ * Date: 2015-07-23
  */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.droplet = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 // Generated from C.g4 by ANTLR 4.5
@@ -62449,6 +62449,9 @@ hook('rebuild_palette', 1, function() {
     hoverDiv = document.createElement('div');
     hoverDiv.className = 'droplet-hover-div';
     hoverDiv.title = (ref2 = data.title) != null ? ref2 : block.stringify();
+    if (data.id != null) {
+      hoverDiv.setAttribute('data-id', data.id);
+    }
     bounds = this.paletteView.getViewNodeFor(block).totalBounds;
     hoverDiv.style.top = bounds.y + "px";
     hoverDiv.style.left = bounds.x + "px";

--- a/content/src/palette.js
+++ b/content/src/palette.js
@@ -5,7 +5,10 @@ function filterblocks(a) {
   }
   return a.map(function(e) {
     if (!e.id) {
-      e.id = e.block.replace(/\W..*$/, '');
+      // As the id (for logging), use the first (non-puncutation) word
+      e.id = e.block.replace(/^\W*/, '').replace(/\W.*$/, '');
+      // If that doesn't turn into anything, use the whole block text.
+      if (!e.id) { e.id = e.block; }
     }
     return e;
   });

--- a/content/src/palette.js
+++ b/content/src/palette.js
@@ -6,7 +6,8 @@ function filterblocks(a) {
   return a.map(function(e) {
     if (!e.id) {
       // As the id (for logging), use the first (non-puncutation) word
-      e.id = e.block.replace(/^\W*/, '').replace(/\W.*$/, '');
+      e.id = e.block.replace(/^\W*/, '').
+             replace(/^new /, '').replace(/\W.*$/, '');
       // If that doesn't turn into anything, use the whole block text.
       if (!e.id) { e.id = e.block; }
     }
@@ -202,15 +203,19 @@ module.exports = {
         }, {
           block: 'x += 1',
           title: 'Increase a variable',
+          id: 'increment'
         }, {
           block: '`` is ``',
-          title: 'Compare two values'
+          title: 'Compare two values',
+          id: 'is'
         }, {
           block: '`` < ``',
-          title: 'Compare two values'
+          title: 'Compare two values',
+          id: 'lessthan'
         }, {
           block: '`` > ``',
-          title: 'Compare two values'
+          title: 'Compare two values',
+          id: 'greaterthan'
         }, {
           block: '`` + ``',
           title: 'Add two numbers',
@@ -256,13 +261,16 @@ module.exports = {
           title: 'Get the smaller on two numbers'
         }, {
           block: 'x.match /pattern/',
-          title: 'Test if a text pattern is found in x'
+          title: 'Test if a text pattern is found in x',
+          id: 'match'
         }, {
           block: 'f = (x) ->\n  ``',
-          title: 'Define a new function'
+          title: 'Define a new function',
+          id: 'funcdef'
         }, {
           block: 'f(x)',
-          title: 'Use a custom function'
+          title: 'Use a custom function',
+          id: 'funccall'
         }
       ])
     }, {
@@ -340,16 +348,20 @@ module.exports = {
           title: 'Play notes in a chord'
         }, {
           block: '@tone \'B\', 2, 1',
-          title: 'Sound a note immediately'
+          title: 'Sound a note immediately',
+          id: 'toneNote'
         }, {
           block: '@tone \'B\', 0',
-          title: 'Silence a note immediately'
+          title: 'Silence a note immediately',
+          id: 'toneNote0'
         }, {
           block: '@tone 440, 2, 1',
-          title: 'Sound a frequency immediately'
+          title: 'Sound a frequency immediately',
+          id: 'toneHz'
         }, {
           block: '@tone 440, 0',
-          title: 'Silence a frequency immediately'
+          title: 'Silence a frequency immediately',
+          id: 'toneHz0'
         }, {
           block: '@silence()',
           title: 'Silence all notes'
@@ -368,25 +380,32 @@ module.exports = {
       blocks: filterblocks([
         {
           block: "forever 10, ->\n  turnto lastmouse\n  fd 2",
-          title: 'Continually move towards the last mouse position'
+          title: 'Continually move towards the last mouse position',
+          id: "foreverFollowMouse"
         }, {
           block: "forever 10, ->\n  if pressed 'W'\n    fd 2",
-          title: 'Poll a key and move while it is depressed'
+          title: 'Poll a key and move while it is depressed',
+          id: "foreverPollKey"
         }, {
           block: "forever 1, ->\n  fd 25\n  if not inside window\n    stop()",
-          title: 'Move once per second until not inside window'
+          title: 'Move once per second until not inside window',
+          id: "foreverInsideWindow"
         }, {
           block: "click (e) ->\n  moveto e",
-          title: 'Move to a location when document is clicked'
+          title: 'Move to a location when document is clicked',
+          id: "foreverMovetoClick"
         }, {
           block: "button \'Click\', ->\n  write 'clicked'",
-          title: 'Make a button and do something when clicked'
+          title: 'Make a button and do something when clicked',
+          id: "buttonWrite"
         }, {
           block: "keydown \'X\', ->\n  write 'x pressed'",
-          title: 'Do something when a keyboard key is pressed'
+          title: 'Do something when a keyboard key is pressed',
+          id: "keydownWrite"
         }, {
           block: "click (e) ->\n  moveto e",
-          title: 'Move to a location when document is clicked'
+          title: 'Move to a location when document is clicked',
+          id: "clickMove"
         }
       ])
     }

--- a/test/edit_code.js
+++ b/test/edit_code.js
@@ -358,7 +358,96 @@ describe('code editor', function() {
       done();
     });
   });
-  it('should enable the save button after editing a program', function(done) {
+  it('should flip into blocks mode', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Click on the "blocks" tabby button
+      $('.blocktoggle').click();
+    }, function() {
+      var lefttitle = $('.panetitle').filter(
+          function() { return $(this).parent().position().left == 0; })
+          .find('.panetitle-text');
+      if (/code/.test(lefttitle.text())) return;
+      return {
+        filename: $('#filename').text(),
+        title: lefttitle.text().trim(),
+        saved: $('#save').prop('disabled')
+      };
+    }, function(err, result) {
+      assert.ifError(err);
+      // Filename is still shown and unchanged.
+      assert.ok(/^untitled/.test(result.filename));
+      // Intentional: we should always add an extra empty line at the bottom.
+      assert.equal(result.title, 'blocks');
+      // The save button is still disabled, because the doc is unmodified.
+      assert.equal(result.saved, true);
+      done();
+    });
+  });
+  it('should be able to drag out a block', function(done) {
+    testutil.defineSimulate(_page);
+    // Capture any /log/ HTTP request.
+    var logged = null;
+    _page.onResourceRequested = function(req) {
+      if (/log/.test(req[0].url)) { logged = req[0].url; }
+    }
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Drag a block out: bk 100
+      simulate('mousedown', '[data-id=bk]')
+      simulate('mousemove', '.droplet-drag-cover',
+        { location: '[data-id=bk]', dx: 5 })
+      simulate('mousemove', '.droplet-drag-cover',
+        { location: '.droplet-main-scroller' })
+      simulate('mouseup', '.droplet-drag-cover',
+        { location: '.droplet-main-scroller' })
+    }, function() {
+      var ace_editor = ace.edit($('.droplet-ace')[0]);
+      // Return a ton of UI state.
+      return {
+        filename: $('#filename').text(),
+        text: ace_editor.getSession().getValue(),
+        saved: $('#save').prop('disabled')
+      };
+    }, function(err, result) {
+      _page.onResourceRequested = null;
+      assert.ifError(err);
+      // The filename chosen should start with the word "untitled"
+      assert.ok(/^untitled/.test(result.filename), result.filename);
+      // The program text should be "bk 100".
+      assert.equal(result.text.trim(), 'bk 100');
+      // The "save" button should not be disabled now.
+      assert.equal(result.saved, false);
+      // And pickblock should have been logged
+      assert.equal(logged,
+        "http://livetest.pencilcode.net.dev/log/~pickblock?id=bk");
+      done();
+    });
+  });
+  it('should flip into text mode again', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Click on the "text" tabby button
+      $('.texttoggle').click();
+    }, function() {
+      var lefttitle = $('.panetitle').filter(
+          function() { return $(this).parent().position().left == 0; })
+          .find('.panetitle-text');
+      if (/blocks/.test(lefttitle.text())) return;
+      return {
+        filename: $('#filename').text(),
+        title: lefttitle.text().trim(),
+        saved: $('#save').prop('disabled')
+      };
+    }, function(err, result) {
+      assert.ifError(err);
+      // Filename is still shown and unchanged.
+      assert.ok(/^untitled/.test(result.filename));
+      // Intentional: we should always add an extra empty line at the bottom.
+      assert.equal(result.title, 'code');
+      // The save button is still enabled
+      assert.equal(result.saved, false);
+      done();
+    });
+  });
+  it('should be able to edit a program in text mode', function(done) {
     asyncTest(_page, one_step_timeout, null, function() {
       // Modify the text in the editor.
       var ace_editor = ace.edit($('.droplet-ace')[0]);

--- a/test/lib/testutil.js
+++ b/test/lib/testutil.js
@@ -96,3 +96,69 @@ function asyncTest(page, timeout, params, action, predicate, callback) {
   }
 }
 
+// Mouse event simluation function.
+// defineSimulate injects a global function "simulate"
+// into the page.
+exports.defineSimulate = function(page) {
+  page.evaluate(function() {
+    window.simulate = function(type, target, options) {
+      if ('string' == typeof(target)) {
+        target = $(target).get(0);
+      }
+      options = options || {};
+      var pageX = pageY = clientX = clientY = dx = dy = 0;
+      var location = options.location || target;
+      if (location) {
+        if ('string' == typeof(location)) {
+          location = $(location).get(0);
+        }
+        var gbcr = location.getBoundingClientRect();
+            clientX = gbcr.left,
+            clientY = gbcr.top,
+            pageX = clientX + window.pageXOffset
+            pageY = clientY + window.pageYOffset
+            dx = Math.floor((gbcr.right - gbcr.left) / 2)
+            dy = Math.floor((gbcr.bottom - gbcr.top) / 2)
+      }
+      if ('dx' in options) { dx = options.dx; }
+      if ('dy' in options) { dy = options.dy; }
+      pageX = (options.pageX == null ? pageX : options.pageX) + dx;
+      pageY = (options.pageY == null ? pageY : options.pageY) + dy;
+      clientX = pageX - window.pageXOffset;
+      clientY = pageY - window.pageYOffset;
+      var opts = {
+          bubbles: options.bubbles || true,
+          cancelable: options.cancelable || true,
+          view: options.view || target.ownerDocument.defaultView,
+          detail: options.detail || 1,
+          pageX: pageX,
+          pageY: pageY,
+          clientX: clientX,
+          clientY: clientY,
+          screenX: clientX + window.screenLeft,
+          screenY: clientY + window.screenTop,
+          ctrlKey: options.ctrlKey || false,
+          altKey: options.altKey || false,
+          shiftKey: options.shiftKey || false,
+          metaKey: options.metaKey || false,
+          button: options.button || 0,
+          which: options.which || 1,
+          relatedTarget: options.relatedTarget || null,
+      }
+      var evt;
+      try {
+        // Modern API supported by IE9+
+        evt = new MouseEvent(type, opts);
+      } catch (e) {
+        // Old API still required by PhantomJS.
+        evt = target.ownerDocument.createEvent('MouseEvents');
+        evt.initMouseEvent(type, opts.bubbles, opts.cancelable, opts.view,
+          opts.detail, opts.screenX, opts.screenY, opts.clientX, opts.clientY,
+          opts.ctrlKey, opts.altKey, opts.shiftKey, opts.metaKey, opts.button,
+          opts.relatedTarget);
+      }
+      target.dispatchEvent(evt);
+    };
+  });
+};
+


### PR DESCRIPTION
"Pickblock" logging was broken a couple months ago, and we didn't notice because there was no test.

The problem was in a regular expression that automatically created the logging id `fd` from blocks like `fd 100`.  When we started encoding turtle-addressable blocks using `@fd 100`, the regular expression stopped working.

This change fixes the bug and also adds a test.