### PR TITLE
Add camera button to capture thumbnail at any time

### DIFF
--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -1420,6 +1420,8 @@ function doneWithFile(filename) {
     }
   } else {
     if (filename.indexOf('/') >= 0) {
+      // `history.state.previous` is like '/edit/demo/', so we should
+      // strip the filename after '/' and keep the '/'.
       filename = filename.replace(/[^\/]+\/?$/, '');
     } else {
       filename = '';

--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -30,6 +30,7 @@ var model = window.pencilcode.model = {
   // Url used for starting the guide.
   guideUrl: null,
   // Contents of the three panes.
+  tempThumbnail: null,
   pane: {
     alpha: {
       filename: null,
@@ -131,6 +132,11 @@ function nosaveowner() {
   return model.ownername === 'frame';
 }
 
+function cansave() {
+  return specialowner() || !model.username || model.tempThumbnail ||
+      view.isPaneEditorDirty(paneatpos('left'));
+}
+
 function updateTopControls(addHistory) {
   var m = modelatpos('left');
   // Update visible URL and main title name.
@@ -156,15 +162,21 @@ function updateTopControls(addHistory) {
       //
       // If so, then insert save button
       //
-      var cansave = specialowner() || !model.username ||
-                    view.isPaneEditorDirty(paneatpos('left'));
       buttons.push(
-        { id: 'save', title: 'Save program (Ctrl+S)', label: 'Save',
+        {
+          id: 'save',
+          title: 'Save program (Ctrl+S)',
+          label: 'Save',
           menu: [
             { id: 'save2', label: 'Save' },
             { id: 'saveas', label: 'Copy and Save As...' }
           ],
-          disabled: !cansave,
+          disabled: !cansave(),
+        },
+        {
+          id: 'screenshot',
+          title: 'Take screenshot',
+          label: '<i class="fa fa-camera"></i>'
         });
 
       // Also insert share button
@@ -399,9 +411,8 @@ view.on('byname', function() {
 
 view.on('dirty', function(pane) {
   if (posofpane(pane) == 'left') {
-    var cansave = specialowner() || view.isPaneEditorDirty(pane);
-    view.enableButton('save', cansave);
-    view.enableButton('save2', cansave);
+    view.enableButton('save', cansave());
+    view.enableButton('save2', cansave());
     // Toggle button between triangle and refresh.
     view.showMiddleButton('run');
   }
@@ -574,6 +585,16 @@ view.on('setpass', function() {
   });
 });
 
+view.on('screenshot', function() {
+  var iframe = document.getElementById('output-frame');
+  // `thumbnail.generateThumbnailDataUrl` second parameter is a callback.
+  thumbnail.generateThumbnailDataUrl(iframe, function(thumbnailDataUrl) {
+    model.tempThumbnail = thumbnailDataUrl;
+    updateTopControls();
+    view.flashThumbnail(thumbnailDataUrl);
+  });
+});
+
 view.on('save', function() { saveAction(false, null, null); });
 view.on('save2', function() { saveAction(false, null, null); });
 view.on('saveas', saveAs);
@@ -742,9 +763,13 @@ function saveAction(forceOverwrite, loginPrompt, doneCallback) {
     console.log("Nothing to save.");
     return;
   } else if (doc.data !== '') { // If program is not empty, generate thumbnail
+    if (model.tempThumbnail) {
+      postThumbnailGeneration(model.tempThumbnail);
+    } else {
       var iframe = document.getElementById('output-frame');
       // `thumbnail.generateThumbnailDataUrl` second parameter is a callback.
       thumbnail.generateThumbnailDataUrl(iframe, postThumbnailGeneration);
+    }
   } else {  // Empty content, file delete, no need for thumbnail.
     postThumbnailGeneration('');
   }
@@ -795,6 +820,7 @@ function saveAction(forceOverwrite, loginPrompt, doneCallback) {
         }
       }
       // Delete the pre-saved thumbnail from the model.
+      model.tempThumbnail = null;
       updateTopControls();
       // Flash the thumbnail after the control are updated.
       view.flashThumbnail(thumbnailDataUrl);
@@ -1613,13 +1639,21 @@ function readNewUrl(undo) {
   // Login from cookie.
       cookielogin = null;
   // Give the user a chance to abort navigation.
-  if (undo && view.isPaneEditorDirty(paneatpos('left')) && !nosaveowner()) {
-    view.flashButton('save');
-    if (!window.confirm(
-      "There are unsaved changes.\n\n" +
+  if (undo && !nosaveowner()) {
+    var type = null;
+    if (view.isPaneEditorDirty(paneatpos('left'))) {
+      type = 'changes';
+    } else if (model.tempThumbnail) {
+      type = 'thumbnail';
+    }
+    if (type && !window.confirm(
+      "There are unsaved " + type + ".\n\n" +
       "Are you sure you want to leave this page?")) {
+      view.flashButton('save');
       undo();
       return;
+    } else {
+      model.tempThumbnail = null;
     }
   }
   if (!login) {

--- a/content/src/controller.js
+++ b/content/src/controller.js
@@ -1394,7 +1394,7 @@ function doneWithFile(filename) {
     }
   } else {
     if (filename.indexOf('/') >= 0) {
-      filename = filename.replace(/\/[^\/]+\/?$/, '');
+      filename = filename.replace(/[^\/]+\/?$/, '');
     } else {
       filename = '';
     }

--- a/content/src/view.js
+++ b/content/src/view.js
@@ -88,11 +88,11 @@ ZeroClipboard.config({
 
 window.pencilcode.view = {
   // Listens to events
-  on: function(tag, cb) { 
+  on: function(tag, cb) {
     if (state.callbacks[tag] == null){
       state.callbacks[tag] = []
     }
-    state.callbacks[tag].push(cb); 
+    state.callbacks[tag].push(cb);
  },
 
   // Simulate firing of an event
@@ -247,7 +247,7 @@ function setOnCallback(tag, cb) {
 function fireEvent(tag, args) {
   if (tag in state.callbacks) {
     var cbs = state.callbacks[tag].slice();
-    //take a copy of the array in case other 
+    //take a copy of the array in case other
     //events are fired while you're indexing it.
     for (j=0; j < cbs.length; j++) {
       var cb = cbs[j];
@@ -735,15 +735,19 @@ function showMiddleButton(which) {
 // Show thumbnail under the save button.
 function flashThumbnail(imageDataUrl) {
   if (!imageDataUrl) { return; }
-  var tooltip = $('#save').tooltipster({
+  // Destroy the original title tooltip once there is a thumbnail.
+  $('#screenshot').tooltipster('destroy');
+  $('#screenshot').tooltipster({
     content: $('<img src=' + imageDataUrl + ' alt="thumbnail">'),
-    multiple: true,
     position: 'bottom',
     theme: 'tooltipster-shadow',
-    timer: 3000,
-    trigger: 'custom'
-  })[0];
-  tooltip.show();
+    interactive: true,
+    timer: 3000
+  });
+  // Flash the thumbnail for 3 seconds, then disable the timer,
+  // so that activation via hovering will not last for only 3 seconds.
+  $('#screenshot').tooltipster('show');
+  $('#screenshot').tooltipster('option', 'timer', 0);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/test/edit_code.js
+++ b/test/edit_code.js
@@ -649,6 +649,26 @@ describe('code editor', function() {
       });
     });
   });
+  it('should capture thumbnail when camera button is pressed', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Then click the save button.
+      $('#screenshot').click();
+    }, function() {
+      // Wait for thumbnail to be flashed
+      if (!$('.tooltipster-shadow').is(':visible')) return;
+      if (!$('img[alt="thumbnail"]').is(':visible')) return;
+      return {
+        saveEnabled: !$('#save').attr('disabled'),
+        dataurl: $('img[alt="thumbnail"]').attr('src')
+      };
+    }, function(err, result) {
+      assert.ifError(err);
+      assert.ok(result.saveEnabled);
+      // Thumbnail should not be empty.
+      assert.ok(result.dataurl.length > 0);
+      done();
+    });
+  });
   it('should delete when empty is saved', function(done) {
     asyncTest(_page, one_step_timeout, null, function() {
       // Delete all the text in the editor!

--- a/test/edit_code.js
+++ b/test/edit_code.js
@@ -651,7 +651,7 @@ describe('code editor', function() {
   });
   it('should capture thumbnail when camera button is pressed', function(done) {
     asyncTest(_page, one_step_timeout, null, function() {
-      // Then click the save button.
+      // Then click the camera button.
       $('#screenshot').click();
     }, function() {
       // Wait for thumbnail to be flashed


### PR DESCRIPTION
* Click on camera button to capture the current output and save temporarily. Then activate the `Save` button.
* Save would try to get the temp thumbnail before falling back to capture one on the spot.
* Show alert when there is an unsaved thumbnail.
* Fix problem that `unsaved changes` alert is not popping up sometimes. 