### PR TITLE
Ignores unmoved turtle when capturing thumbnails

### DIFF
--- a/content/src/thumbnail.js
+++ b/content/src/thumbnail.js
@@ -10,11 +10,30 @@ var thumbnail = {
     // Get the canvas inside the iframe.
     var innerDoc = iframe.contentDocument || iframe.contentWindow.document;
     var innerBody = innerDoc.body;
+    var jqueryTurtle = iframe.contentWindow.$;
+
+    // An extra array to store modified elements.
+    var hiddenElements = [];
+
+    var turtles = innerDoc.getElementsByClassName('turtle');
+    // If there is only a single turtle.
+    if (turtles.length === 1 && turtles[0].id === 'turtle') {
+      var turtle = turtles[0];
+      var coordinates = jqueryTurtle(turtle).getxy();
+      var direction = jqueryTurtle(turtle).direction();
+      // If the turtle is at its original position and direction, ignore it.
+      if (coordinates && coordinates[0] === 0 && coordinates[1] === 0 &&
+          direction === 0) {
+        hiddenElements.push({
+          object: turtle,
+          display: turtle.style.display
+        });
+        turtle.style.display = 'none';
+      }
+    }
 
     // Copy the NodeList into an array.
     var children = Array.prototype.slice.call(innerBody.children);
-    // An extra array to store modified elements.
-    var hiddenElements = [];
 
     // Hide the test panel and coordinates before capturing the thumbnail.
     // Keep a copy of the original style settings in the `hiddenElements` array.

--- a/content/src/thumbnail.js
+++ b/content/src/thumbnail.js
@@ -10,17 +10,18 @@ var thumbnail = {
     // Get the canvas inside the iframe.
     var innerDoc = iframe.contentDocument || iframe.contentWindow.document;
     var innerBody = innerDoc.body;
-    var jqueryTurtle = iframe.contentWindow.$;
+    var framejQuery = iframe.contentWindow.$;
 
     // An extra array to store modified elements.
     var hiddenElements = [];
 
     var turtles = innerDoc.getElementsByClassName('turtle');
     // If there is only a single turtle.
-    if (turtles.length === 1 && turtles[0].id === 'turtle') {
+    if (typeof(frameJQuery) === 'function' && frameJQuery.turtle &&
+        turtles.length === 1 && turtles[0].id === 'turtle') {
       var turtle = turtles[0];
-      var coordinates = jqueryTurtle(turtle).getxy();
-      var direction = jqueryTurtle(turtle).direction();
+      var coordinates = framejQuery(turtle).getxy();
+      var direction = framejQuery(turtle).direction();
       // If the turtle is at its original position and direction, ignore it.
       if (coordinates && coordinates[0] === 0 && coordinates[1] === 0 &&
           direction === 0) {

--- a/test/edit_code.js
+++ b/test/edit_code.js
@@ -518,8 +518,29 @@ describe('code editor', function() {
       done();
     });
   });
+  it('should capture thumbnail when camera button is pressed', function(done) {
+    asyncTest(_page, one_step_timeout, null, function() {
+      // Then click the camera button.
+      $('#screenshot').click();
+    }, function() {
+      // Wait for thumbnail to be flashed
+      if (!$('.tooltipster-shadow').is(':visible')) return;
+      if (!$('img[alt="thumbnail"]').is(':visible')) return;
+      return {
+        saveEnabled: !$('#save').attr('disabled'),
+        dataurl: $('img[alt="thumbnail"]').attr('src')
+      };
+    }, function(err, result) {
+      assert.ifError(err);
+      assert.ok(result.saveEnabled);
+      // Thumbnail should not be empty.
+      assert.ok(result.dataurl.length > 0);
+      done();
+    });
+  });
   it('should flash thumbnail after run and save', function(done) {
     asyncTest(_page, one_step_timeout, null, function() {
+      $('.tooltipster-shadow').hide();
       // Then click the save button.
       $('#save').click();
     }, function() {
@@ -736,26 +757,6 @@ describe('code editor', function() {
         assert.ok(/login=/.test(result.cookie));
         done();
       });
-    });
-  });
-  it('should capture thumbnail when camera button is pressed', function(done) {
-    asyncTest(_page, one_step_timeout, null, function() {
-      // Then click the camera button.
-      $('#screenshot').click();
-    }, function() {
-      // Wait for thumbnail to be flashed
-      if (!$('.tooltipster-shadow').is(':visible')) return;
-      if (!$('img[alt="thumbnail"]').is(':visible')) return;
-      return {
-        saveEnabled: !$('#save').attr('disabled'),
-        dataurl: $('img[alt="thumbnail"]').attr('src')
-      };
-    }, function(err, result) {
-      assert.ifError(err);
-      assert.ok(result.saveEnabled);
-      // Thumbnail should not be empty.
-      assert.ok(result.dataurl.length > 0);
-      done();
     });
   });
   it('should delete when empty is saved', function(done) {


### PR DESCRIPTION
Ignores the turtle when all the below conditions are met:
1. There is only 1 turtle.
2. The turtle is the default one. (i.e. with id `#turtle`)
3. The turtle has not moved. 
4. The direction of the turtle has not changed. 