### PR TITLE
Catch canvas tainted error and proceed without a thumbnail

### DIFF
--- a/content/src/thumbnail.js
+++ b/content/src/thumbnail.js
@@ -54,12 +54,7 @@ var thumbnail = {
       hiddenElements.forEach(function(element) {
         element.object.style.display = element.display;
       });
-      try {
-        callback(getImageDataUrl(canvas));
-      } catch (e) {
-        console.log('Capturing thumbnail failed, skipping...')
-        callback('');
-      }
+      callback(getImageDataUrl(canvas));
     }
 
     function tryHtml2canvas(numAttempts) {
@@ -85,7 +80,14 @@ function getImageDataUrl(canvas) {
   var w = canvas.width;
   var h = canvas.height;
   var ctx = canvas.getContext('2d');
-  var imageData = ctx.getImageData(0, 0, w, h);
+  var imageData;
+  try {
+    // Try to get image data. Would fail if canvas is tainted.
+    imageData = ctx.getImageData(0, 0, w, h);
+  } catch (e) {
+    console.log('Get image data failed, skipping...')
+    return '';
+  }
 
   // Initialize the coordinates for the image region,
   // topLeft is initialized to bottom right,

--- a/content/src/thumbnail.js
+++ b/content/src/thumbnail.js
@@ -54,7 +54,12 @@ var thumbnail = {
       hiddenElements.forEach(function(element) {
         element.object.style.display = element.display;
       });
-      callback(getImageDataUrl(canvas));
+      try {
+        callback(getImageDataUrl(canvas));
+      } catch (e) {
+        console.log('Capturing thumbnail failed, skipping...')
+        callback('');
+      }
     }
 
     function tryHtml2canvas(numAttempts) {


### PR DESCRIPTION
Regarding #183

:disappointed: `html2canvas` doesn't throw an error when the canvas is tainted. Error is only thrown by the canvas when I try to get image data from it. 

So in addition to catching errors thrown by `html2canvas`, errors thrown by the canvas during the post-processing of the `html2canvas` result also needs to be caught. We would ignore the error and proceed without a thumbnail. 