### PR TITLE
Removed fs-ext dependency, so now everything builds and runs on vanilla Windows 10 (WSL not required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,30 @@
+
 How To Build and Test PencilCode
 ================================
 [![Build Status](https://travis-ci.org/PencilCode/pencilcode.png?branch=master)](https://travis-ci.org/PencilCode/pencilcode)
-First install the prerequisites: git, nodejs, and grunt. Next, be sure you're in your home directory. Then:
 
-<pre>
-git clone https://github.com/PencilCode/pencilcode.git
-cd pencilcode
-npm install
-grunt
-grunt devserver
-</pre>
-
-On Windows Subsystem for Linux (WSL) *only*:
-
-<pre>
-git clone https://github.com/cacticouncil/pencilcode.git
-cd pencilcode
-npm install --no-shrinkwrap
-grunt
-grunt devserver
-</pre>
-
-Development can be done on Linux, Mac, or Windows.
-The prerequisites are a standard node.js development environment
-which is very widely used, plus grunt (you'll need to
-`npm install -g grunt-cli`).
 
 Prerequisites
 -------------
+There are three prerequisites: git, node.js, and grunt. Instructions are noted by operating system.
 
-First, you need git, which is easy.  On Linux,
-just `sudo apt-get install git` or `sudo yum install git-core`
-if you don't have it.
+__Linux:__
 
-Second, you need node.js (which is the `node` and `npm` binaries)
-and `grunt` (which is the build tool popular in the node.js community).
-The Ubuntu and Debian packages for node.js are pretty old, so don't
-just apt-get install the packages.  Get and build the latest `node` and
-`npm` and `grunt` binaries as follows:
+1. Git -
+`sudo apt-get install git` on Debian/Ubuntu
+`sudo yum install git-core` on CentOS / Redhat / Fedora
 
-(For Linux:)
-
+2. Node.js -
+Some modern systems have recent enough tools to install node.js via the package manager. Here is how you'd do so on Ubuntu (native or under WSL):
+<pre>
+sudo apt-get install npm git
+sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
+sudo npm install -g grunt-cli
+</pre>
+If you are not sure, it is recommended you get and build the latest `node`, `npm`, and `grunt` binaries as follows:
 <pre>
 mkdir -p /tmp/nodejs && cd /tmp/nodejs
-wget -N http://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz # http://nodejs.org/dist/node-latest.tar.gz
+wget -N http://nodejs.org/dist/v7.4.0/node-v7.4.0.tar.gz # http://nodejs.org/dist/node-latest.tar.gz
 tar xzvf node-*.tar.gz && cd `ls -d node-v*`
 ./configure --prefix=$HOME/local
 make install
@@ -53,19 +34,18 @@ npm install -g grunt-cli
 </pre>
 Zsh users should change `bashrc` to `zshrc` in the above code.
 
-(For Windows Subsystem for Linux:)
+__Mac:__
 
-<pre>
-sudo apt-get install npm git
-sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
-sudo npm install -g grunt-cli
-</pre>
+1. On the Mac, git comes from Apple (you can get it as part of the
+[Command line tools for XCode](https://developer.apple.com/downloads/index.action?q=xcode#)),
+and if you'd rather not build it, node.js can be installed from
+http://nodejs.org/download/.
+You will still need to `sudo npm install -g grunt-cli`.
 
-(For Mac:)
-
+2. You'll need to install node.js as well:
 <pre>
 mkdir -p /tmp/nodejs && cd /tmp/nodejs
-curl http://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz > node-latest.tar.gz
+curl http://nodejs.org/dist/v7.4.0/node-v7.4.0.tar.gz > node-latest.tar.gz
 tar xzvf node-*.tar.gz && cd `ls -d node-v*`
 ./configure --prefix=$HOME/local
 make install
@@ -74,23 +54,25 @@ source ~/.profile
 npm install -g grunt-cli
 </pre>
 
-The above drops all the built binaries into `~/local/bin` so you
-don't need root.
+The above drops all the built binaries into `~/local/bin` so you don't need root.
 
-On the Mac, git comes from Apple (you can get it as part of the
-[Command line tools for XCode](https://developer.apple.com/downloads/index.action?q=xcode#)),
-and if you'd rather not build it, node.js can be installed from
-http://nodejs.org/download/.
-You will still need to `sudo npm install -g grunt-cli`.
+__Windows:__
 
-On Windows, git can be installed from here:
-http://git-scm.com/download/win and node.js can be installed
-from here: http://nodejs.org/download/.  Windows development
-is untested, but if you try it, let me know.
+1. Git can be installed from here: http://git-scm.com/download/win
 
-Because node.js does not work on cygwin, when I work with node.js
-on a Windows box, I just run it with debian under a vbox instance
-https://www.virtualbox.org/.
+2. Node.js v7.x can be installed from here: http://nodejs.org/download/
+
+
+Building and Running
+---------------------
+To clone the repository, build, and run, execute these commands:
+<pre>
+git clone https://github.com/PencilCode/pencilcode.git
+cd pencilcode
+npm install
+grunt
+grunt devserver
+</pre>
 
 
 How To Experiment with PencilCode

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "debug": "latest",
     "dynamic.io": "latest",
     "express": "latest",
-    "fs-ext": "latest",
     "fs-extra": "latest",
     "http-proxy": "latest",
     "log-timestamp": "latest",

--- a/server/dirloader.js
+++ b/server/dirloader.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs-ext');
+var fs = require('fs');
 var lb = require('binary-search-bounds').ge;
 var utils = require('./utils');
 

--- a/server/load.js
+++ b/server/load.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var fs = require('fs-ext');
+var fs = require('fs');
 var fsExtra = require('fs-extra');
 var utils = require('./utils');
 var filetype = require('../content/src/filetype');


### PR DESCRIPTION
Reasons:

1) fs-ext does not work on Windows 10 outside of WSL.
2) We can't build the standalone in WSL (it requires "native" Windows tools)
3) fs-ext was no longer necessary - latest version of Node has all required functions incorporated into code base.

These changes remove the fs-ext dependency, allowing native Windows support (and therefore Standalone build support.)